### PR TITLE
add neuronx-distributed-inference dep

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -4,3 +4,4 @@ urllib3>=2.6.0
 
 # vLLM installation
 vllm==0.13.0
+neuronx-distributed-inference>=0.7


### PR DESCRIPTION
To address https://github.com/vllm-project/vllm-neuron/issues/8


Verified with AWS neuron dlami py venv `/opt/aws_neuronx_venv_pytorch_2_9`