### PR TITLE
feat: NixlConnector support for Neuron disaggregated inference

### DIFF
--- a/vllm_neuron/attention/neuron_attn.py
+++ b/vllm_neuron/attention/neuron_attn.py
@@ -27,4 +27,4 @@ class NeuronAttentionBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        raise NotImplementedError
+        return (2, num_blocks, block_size, num_kv_heads, head_size)

--- a/vllm_neuron/platform.py
+++ b/vllm_neuron/platform.py
@@ -268,8 +268,9 @@ class NeuronPlatform(Platform):
         block_size: int,
         use_v1: bool,
         use_mla: bool,
-        has_sink,
-        use_sparse,
+        has_sink=False,
+        use_sparse=False,
+        **kwargs,
     ) -> str:
         if selected_backend != _Backend.NEURON_ATTN:
             logger.warning(
@@ -439,12 +440,19 @@ class NeuronPlatform(Platform):
 
     @classmethod
     def get_nixl_supported_devices(cls) -> dict[str, tuple[str, ...]]:
+        """Neuron supports NIXL KV transfer via CPU host buffer only.
+
+        Trainium/Inferentia device memory cannot be directly registered with
+        NIXL (no CUDA driver, no Level Zero). KV cache blocks are staged
+        through pinned CPU DRAM and transferred via NIXL LIBFABRIC over
+        EFA RDMA -- the same pattern used by TPU and XPU.
         """
-        Returns a mapping from device_type to a tuple of supported
-        kv_buffer_device for nixl.
-        Neuron supports "cpu" now.
-        """
-        return {NeuronPlatform.device_type: {"cpu"}}
+        return {NeuronPlatform.device_type: ("cpu",)}
+
+    @classmethod
+    def get_nixl_memory_type(cls) -> str | None:
+        """NIXL memory type for Neuron: always DRAM (host-buffered)."""
+        return "DRAM"
 
     @classmethod
     def device_id_to_physical_device_id(cls, device_id: int):

--- a/vllm_neuron/worker/neuron_worker.py
+++ b/vllm_neuron/worker/neuron_worker.py
@@ -198,6 +198,26 @@ class NeuronWorker(WorkerBase):
 
         ensure_kv_transfer_initialized(vllm_config)
 
+    def get_kv_connector_handshake_metadata(self):
+        """Return NIXL handshake metadata for KV connector discovery.
+
+        The V1 engine calls this during startup to exchange NIXL agent
+        metadata between prefill and decode workers. Without this, the
+        workers cannot discover each other for KV cache transfer.
+        """
+        from vllm.distributed.kv_transfer import (
+            has_kv_transfer_group,
+            get_kv_transfer_group,
+        )
+        from vllm.distributed.parallel_state import get_tp_group
+        if not has_kv_transfer_group():
+            return None
+        connector = get_kv_transfer_group()
+        metadata = connector.get_handshake_metadata()
+        if metadata is None:
+            return None
+        return {get_tp_group().rank_in_group: metadata}
+
     def shutdown(self) -> None:
         self.model_runner.ensure_kv_transfer_shutdown()
 

--- a/vllm_neuron/worker/neuronx_distributed_model_runner.py
+++ b/vllm_neuron/worker/neuronx_distributed_model_runner.py
@@ -457,7 +457,89 @@ class NeuronxDistributedModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunner
                         kv_caches[f"tp{rank}_layer{layer}_k"] = kv_on_tp_rank[k_key]
                         kv_caches[f"tp{rank}_layer{layer}_v"] = kv_on_tp_rank[v_key]
 
-            get_kv_transfer_group().register_kv_caches(kv_caches)
+            # P2/P9/P10: Move KV tensors to CPU and reshape NxDI BHSD layout
+            # into CUDA paged block format for NIXL compatibility.
+            #
+            # NxDI produces K,V tensors of shape (batch, kv_heads, seq_len, head_dim).
+            # NIXL/NixlConnector expects CUDA FlashAttention paged format:
+            #   (2, num_blocks, block_size, kv_heads, head_dim) per layer.
+            #
+            # Also aligns the number of blocks to kv_cache_config.num_blocks
+            # (the scheduler's block pool) to prevent:
+            #   makeXferReq: remote index out of range
+            import torch as _torch
+            _block_size = self.cache_config.block_size
+            _num_gpu_blocks = kv_cache_config.num_blocks
+            _aligned_kv = {}
+            _layer_k = {}
+            _layer_v = {}
+
+            logger.info(
+                "NIXL KV reshape: block_size=%d, num_gpu_blocks=%d (scheduler pool)",
+                _block_size, _num_gpu_blocks
+            )
+
+            for key, tensor in kv_caches.items():
+                t = tensor.cpu().contiguous() if str(tensor.device) != 'cpu' else tensor.contiguous()
+                if t.dim() == 4:
+                    batch, kv_heads, seq_len, head_dim = t.shape
+                    assert batch == 1, f"Expected batch=1, got {batch}"
+                    t = t.squeeze(0)
+                    _nxdi_blocks = seq_len // _block_size
+                    assert seq_len == _nxdi_blocks * _block_size, \
+                        f"seq_len {seq_len} not divisible by block_size {_block_size}"
+                    t = t.reshape(kv_heads, _nxdi_blocks, _block_size, head_dim)
+                    t = t.permute(1, 2, 0, 3).contiguous()
+                    if _nxdi_blocks < _num_gpu_blocks:
+                        padded = _torch.zeros(
+                            (_num_gpu_blocks, _block_size, kv_heads, head_dim),
+                            dtype=t.dtype, device='cpu'
+                        )
+                        padded[:_nxdi_blocks].copy_(t)
+                        t = padded
+                    elif _nxdi_blocks > _num_gpu_blocks:
+                        t = t[:_num_gpu_blocks].contiguous()
+
+                parts = key.split('_')
+                layer_idx = None
+                is_k = None
+                for part in parts:
+                    if part.startswith('layer'):
+                        layer_idx = int(part[5:])
+                    if part == 'k':
+                        is_k = True
+                    elif part == 'v':
+                        is_k = False
+                    elif part == 'kv':
+                        is_k = None
+
+                if layer_idx is not None:
+                    if is_k is True:
+                        _layer_k[layer_idx] = t
+                    elif is_k is False:
+                        _layer_v[layer_idx] = t
+                    else:
+                        _aligned_kv[f"layer_{layer_idx}"] = t
+                else:
+                    _aligned_kv[key] = t
+
+            for layer_idx in sorted(set(list(_layer_k.keys()) + list(_layer_v.keys()))):
+                k_t = _layer_k.get(layer_idx)
+                v_t = _layer_v.get(layer_idx)
+                if k_t is not None and v_t is not None:
+                    _aligned_kv[f"layer_{layer_idx}"] = _torch.stack([k_t, v_t], dim=0)
+                elif k_t is not None:
+                    _aligned_kv[f"layer_{layer_idx}_k"] = k_t
+                elif v_t is not None:
+                    _aligned_kv[f"layer_{layer_idx}_v"] = v_t
+
+            if _aligned_kv:
+                _sample = next(iter(_aligned_kv.values()))
+                logger.info(
+                    "NIXL KV reshape: %d layers, sample shape=%s, dtype=%s",
+                    len(_aligned_kv), _sample.shape, _sample.dtype
+                )
+            get_kv_transfer_group().register_kv_caches(_aligned_kv)
 
     def _get_nxdi_lora_config(self):
         """
@@ -742,11 +824,34 @@ class NeuronxDistributedModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunner
         logger.debug("model_input: %s", model_input)
 
         # NOTE: setup current batch's metadata for kv connector.
-        # Currently, only verified with NixlConnector
-        with (
-            set_forward_context(None, self.vllm_config),
-            self.maybe_get_kv_connector_output(scheduler_output) as kv_connector_output,
-        ):
+        # Currently, only verified with NixlConnector.
+        # P6: Skip the KV connector context manager when there are no pending
+        # transfers, to avoid blocking on start_load_kv() every iteration.
+        _kv_md = getattr(scheduler_output, 'kv_connector_metadata', None)
+        _has_kv_work = bool(
+            _kv_md and (
+                getattr(_kv_md, 'reqs_to_recv', None)
+                or getattr(_kv_md, 'reqs_to_send', None)
+            )
+        )
+        if _has_kv_work:
+            _ctx_mgrs = (
+                set_forward_context(None, self.vllm_config),
+                self.maybe_get_kv_connector_output(scheduler_output),
+            )
+        else:
+            _ctx_mgrs = (
+                set_forward_context(None, self.vllm_config),
+            )
+
+        import contextlib
+        kv_connector_output = None
+        with contextlib.ExitStack() as _stack:
+            for _ctx in _ctx_mgrs:
+                _result = _stack.enter_context(_ctx)
+            if _has_kv_work:
+                kv_connector_output = _result
+
             # Execute model forward pass (no sampling - deferred to sample_tokens())
             model_exec_start = time.perf_counter()
             if self.model.architecture in NEURON_MULTI_MODAL_MODELS:
@@ -1399,7 +1504,7 @@ class NeuronxDistributedModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunner
 
         # pad the block_table to have the length of num_gpu_blocks
         block_size = self.cache_config.block_size
-        max_len = self.scheduler_config.max_model_len
+        max_len = self.model_config.max_model_len
         max_blocks_per_seq = max_len // block_size
         padded_block_table = [self._BLOCK_TABLE_PAD] * max_blocks_per_seq
         padded_block_table[: len(block_table)] = block_table[:]


### PR DESCRIPTION
## Summary

Adds NixlConnector (NIXL KV cache transfer) support to vllm-neuron, enabling disaggregated prefill/decode serving where a Trainium worker handles prefill and an NVIDIA GPU worker handles decode. KV cache is transferred from Neuron device memory through CPU DRAM via NIXL LIBFABRIC over EFA RDMA.

This follows the same host-buffer pattern already established by TPU and XPU in vLLM core: accelerator device memory that cannot be directly registered with NIXL is staged through pinned CPU DRAM.

**Proven by POC:** Trainium prefill (24ms) → NIXL RDMA transfer → H100 decode (2139ms total, Qwen3-0.6B) via Dynamo with KV-aware routing.

## Changes

### 1. `vllm_neuron/attention/neuron_attn.py` — Implement `get_kv_cache_shape()`

The `NotImplementedError` stub is replaced with the actual KV cache shape matching CUDA FlashAttention paged block format:
```python
return (2, num_blocks, block_size, num_kv_heads, head_size)
```

**Why:** NixlConnector calls `get_kv_cache_shape()` during handshake to compute block offsets. Without this, the connector crashes at startup.

### 2. `vllm_neuron/worker/neuronx_distributed_model_runner.py` — KV reshape + block alignment

Moves KV tensors to CPU and reshapes NxDI's BHSD layout `(batch, kv_heads, seq_len, head_dim)` into CUDA paged block format `(2, num_blocks, block_size, kv_heads, head_dim)`. Also aligns the block count to `kv_cache_config.num_blocks` (the scheduler's pool size) to prevent `makeXferReq: remote index out of range`.

**Why:** NIXL cannot register Neuron device memory (no CUDA, no Level Zero). This is the same pattern TPU and XPU use — stage KV through CPU DRAM. The reshape ensures NixlConnector can index into the paged blocks correctly.

### 3. `vllm_neuron/worker/neuron_worker.py` — Add `get_kv_connector_handshake_metadata()`

```python
def get_kv_connector_handshake_metadata(self):
    from vllm.distributed.kv_transfer import has_kv_transfer_group, get_kv_transfer_group
    from vllm.distributed.parallel_state import get_tp_group
    if not has_kv_transfer_group():
        return None
    connector = get_kv_transfer_group()
    metadata = connector.get_handshake_metadata()
    if metadata is None:
        return None
    return {get_tp_group().rank_in_group: metadata}
```

**Why:** The V1 engine calls this method during startup to exchange NIXL agent metadata between workers. Without it, the prefill and decode workers cannot discover each other.

### 4. `vllm_neuron/platform.py` — Accept `**kwargs` in `get_attn_backend_cls()`

Adds `**kwargs` and default values for `has_sink` and `use_sparse` parameters.

**Why:** vLLM 0.16+ added new keyword arguments to this method. Without `**kwargs`, the Neuron platform crashes on the new arguments.

### 5. `vllm_neuron/worker/neuronx_distributed_model_runner.py` — Skip NIXL context when no transfers pending

Guards the KV connector context manager entry with a check for actual pending transfers (`reqs_to_recv` or `reqs_to_send`).

**Why:** The NIXL context manager calls `start_load_kv()` which blocks waiting for incoming data. On non-transfer iterations (the majority of decode iterations), this hangs the worker indefinitely.

### 6. `vllm_neuron/worker/neuronx_distributed_model_runner.py` — Fix `max_model_len` attribute

```python
# Before:
max_len = self.scheduler_config.max_model_len
# After:
max_len = self.model_config.max_model_len
```

**Why:** In the disaggregated inference path, `max_model_len` is on `ModelConfig`, not `SchedulerConfig`.

### 7. `vllm_neuron/platform.py` — Fix `get_nixl_supported_devices()` + add `get_nixl_memory_type()`

- Returns `("cpu",)` (tuple) instead of `{"cpu"}` (set) to match the expected type
- Adds `get_nixl_memory_type()` returning `"DRAM"` for host-buffered transfers
- Improved docstrings

## Runtime Workarounds (not in this PR)

Two patches target code outside `vllm-neuron` and must be applied at runtime:

- **P5** (`vllm/v1/executor/uniproc_executor.py`): Force `max_concurrent_batches=1`. Neuron compilation and execution are synchronous — the default async batch overlap causes race conditions.
- **P8** (`NxD Inference application_base.py`): Add `--skip-pass=SimplifyNeuronTensor` compiler flag. Workaround for NCC_ITEN404 compiler crash with paged attention HLO.

## Testing

**Hardware:** trn1.32xlarge (prefill) + p5.48xlarge/H100 (decode), same VPC/AZ, EFA RDMA

**End-to-end test via Dynamo:**

```bash
# Start Dynamo frontend + prefill (Trainium) + decode (H100)
kubectl apply -f disagg_trainium_cuda_efa.yaml

# Send request
curl -s http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-0.6B","prompt":"What is AI?","max_tokens":30}'
```

**Result:** 24.2ms prefill on Trainium, 2139ms total with 30 tokens decoded on H100.

**Configuration:**

```bash
# Prefill (Trainium)
--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'

# Decode (NVIDIA GPU)
--kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda","kv_connector_extra_config":{"backends":["LIBFABRIC"]}}'
```

## Known Limitations

- Prefix caching must be disabled on Trainium due to neuronx-cc NCC_ITEN404 bug (filed as [aws-neuron/aws-neuron-sdk#1304](https://github.com/aws-neuron/aws-neuron-sdk/issues/1304))
- `max-num-seqs` must be 1 on Trainium to avoid the same compiler bug

## Related Issues

- aws-neuron/aws-neuron-sdk#1304 — NCC_ITEN404 compiler crash with paged attention
- vllm-project/vllm#14523 — NIXL disaggregated serving (tracking issue)
- ai-dynamo/dynamo#7673 — XPU+CUDA disagg example (our work adapts this for Trainium+CUDA)