### PR TITLE
Align compile-cache env var, source-install note, and prefix-caching comment with v0.21 behavior

### DIFF
--- a/docs/guides/features-guide.md
+++ b/docs/guides/features-guide.md
@@ -41,11 +41,12 @@ nodes never compile at startup.
 
 ### Pre-compiled model artifacts
 
-You can also use `NEURON_COMPILED_ARTIFACTS` to point at a directory of
-pre-compiled models:
+You can also point `VLLM_CACHE_ROOT` at a directory that holds a
+pre-compiled cache (the compile cache lives at
+`$VLLM_CACHE_ROOT/neuron/compile_cache`):
 
 ```bash
-export NEURON_COMPILED_ARTIFACTS=/path/to/cache
+export VLLM_CACHE_ROOT=/path/to/cache
 vllm serve openai/gpt-oss-20b --tensor-parallel-size 8
 ```
 
@@ -982,7 +983,7 @@ reference, see [Configuration options](reference-configuration.md).
 
 - Reduce the number of `num_batched_tokens_buckets` and
   `num_seqs_buckets`
-- Use `NEURON_COMPILED_ARTIFACTS` to cache compiled models between
+- Use `VLLM_CACHE_ROOT` to cache compiled models between
   restarts
 - Set `VLLM_NEURON_PARALLEL_COMPILE_WORKERS` to increase parallel
   compilation

--- a/docs/guides/how-to-profile-workloads.md
+++ b/docs/guides/how-to-profile-workloads.md
@@ -225,7 +225,7 @@ Open in Neuron Explorer to verify traces were captured correctly.
 - **Possible solution**: Ensure NEFFs are present in the `neffs/`
   subdirectory of the output. They should be auto-copied from the
   compile cache. If missing, set the compile cache path via
-  `NEURON_COMPILED_ARTIFACTS`.
+  `VLLM_CACHE_ROOT`.
 
 ### Profile shows no activity
 

--- a/docs/guides/reference-configuration.md
+++ b/docs/guides/reference-configuration.md
@@ -153,7 +153,7 @@ For conceptual overview, see [Compilation](features-guide.md#compilation).
 
 | Variable | Type | Default | Description |
 | ---- | ---- | ---- | ---- |
-| `NEURON_COMPILED_ARTIFACTS` | str | -- | Path to cache/load compiled models. Skips recompilation when valid artifacts exist. |
+| `VLLM_CACHE_ROOT` | str | `~/.cache/vllm` | Root of the compile cache; NEFFs are cached under `$VLLM_CACHE_ROOT/neuron/compile_cache` and reused across restarts. |
 | `VLLM_NEURON_CPU_COMPILE` | bool | 0 | Enable CPU-only compilation mode (compile NEFFs without Neuron hardware). |
 | `NEURON_PLATFORM_TARGET_OVERRIDE` | str | -- | Target platform for CPU compile mode (e.g., `trn2`). Required when `VLLM_NEURON_CPU_COMPILE=1`. |
 | `VLLM_NEURON_PARALLEL_COMPILE_WORKERS` | int | -- | Number of parallel compilation workers. |
@@ -237,7 +237,7 @@ outputs = llm.generate(prompts, sampling_params)
 Equivalent CLI:
 
 ```bash
-export NEURON_COMPILED_ARTIFACTS=/opt/neuron-cache/gpt-oss-20b
+export VLLM_CACHE_ROOT=/opt/neuron-cache/gpt-oss-20b
 export VLLM_NEURON_PARALLEL_COMPILE_WORKERS=4
 export VLLM_NEURON_KV_GMU_BUDGET_CAP_FRACTION=0.35
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -20,6 +20,14 @@ ml_dtypes
 # NIXL KV transfer (disaggregated inference)
 nixl
 
+# Neuron runtime required by the model path (nki is imported unconditionally,
+# e.g. vllm_neuron/functional/argsort_unstable.py). Install from the Neuron
+# pip index (see the setup guide's --extra-index-url). libtorch-neuronx-lite
+# requires torch==2.11.*, matching vLLM's torch pin.
+nki>=0.5.0
+neuronx-cc~=2.26
+libtorch-neuronx-lite==2.11.*
+
 # benchmark dependency
 psutil
 requests

--- a/vllm_neuron/vllm/worker/neuron_model_runner.py
+++ b/vllm_neuron/vllm/worker/neuron_model_runner.py
@@ -406,10 +406,10 @@ class NeuronModelRunner(KVConnectorModelRunnerMixin):
         # Current: No LORA config or manager initialization
         # Target: self.lora_config = vllm_config.lora_config if vllm_config else None; self.lora_manager = None
 
-        # TODO: Add prefix caching support check
-        # Why required: Prevents silent failures when APC is enabled (not yet supported on Neuron)
-        # Current: No validation, will fail silently or cause incorrect behavior
-        # Target: Raise NotImplementedError if cache_config.enable_prefix_caching is True with clear error message
+        # NOTE: Automatic Prefix Caching (APC) IS supported and is validated
+        # later in __init__: when enable_prefix_caching is True, segmented
+        # prefill must be enabled (max_num_batched_tokens must be a supported
+        # segment size), otherwise a ValueError is raised. See the guard below.
         self.model: Any | None = None
         self._is_synthetic_model: bool = False
         self._tensor_capture_model = None


### PR DESCRIPTION
## Purpose

Fixes three inconsistencies found during hands-on testing of the v0.21.0.1.0.0 beta on trn2.3xlarge. Two are documentation/comment only; one is an additive dependency declaration (no existing pin is changed). Resolves https://github.com/vllm-project/vllm-neuron/issues/38.

1. `NEURON_COMPILED_ARTIFACTS` is documented in three files as the compile-cache path knob, but it is unreferenced in the installed package; the effective knob is `VLLM_CACHE_ROOT` (`get_neuron_compile_cache_dir()` -> `$VLLM_CACHE_ROOT/neuron/compile_cache`). This PR updates all doc occurrences to `VLLM_CACHE_ROOT`.
2. A from-source install (`pip install -e .`) does not pull the Neuron Python runtime, so the first model import fails with `ModuleNotFoundError: No module named 'nki'` even though `current_platform.device_name` returns `neuron`. `nki` is imported unconditionally on the model path (e.g. `vllm_neuron/functional/argsort_unstable.py`). This PR declares the runtime in `requirements/core.txt` (`nki>=0.5.0`, `neuronx-cc~=2.26`, `libtorch-neuronx-lite==2.11.*`), installed from the Neuron pip index. `libtorch-neuronx-lite==2.11.*` matches vLLM's existing torch pin, so this is purely additive. The setup guide is intentionally not modified.
3. `neuron_model_runner.py` had a stale TODO claiming APC is unsupported/unvalidated; APC is supported and guarded by a `ValueError` (requires segmented prefill) later in `__init__`. Replaced the TODO with a NOTE describing the implemented guard.

Files: `docs/guides/features-guide.md`, `docs/guides/reference-configuration.md`, `docs/guides/how-to-profile-workloads.md`, `requirements/core.txt`, `vllm_neuron/vllm/worker/neuron_model_runner.py` (5 files). `docs/getting-started/setup-guide.md` is unchanged.

## Test Plan

Run on a trn2.3xlarge. Item 2 changes an installable dependency, so beyond the fact checks it is verified end to end (install -> serve -> inference), because the concern is precisely whether the added deps induce a new install conflict or a runtime regression.

1. Confirm `NEURON_COMPILED_ARTIFACTS` is unused:
   `grep -rn "NEURON_COMPILED_ARTIFACTS" <site-packages> --include="*.py"` (including `neuronxcc`, `torch_xla`).
2. Confirm `VLLM_CACHE_ROOT` is the real knob:
   `python -c "from vllm_neuron.envs import get_neuron_compile_cache_dir as g; print(g())"` with and without `VLLM_CACHE_ROOT` set.
3. Confirm the core.txt change installs cleanly and does not induce a conflict or downgrade: on a clean Python 3.12 venv,
   `pip install -e . --extra-index-url=https://pip.repos.neuron.amazonaws.com`, then check `torch.__version__`, `import nki`, and `from vllm_neuron.model.registry import get_models; print(get_models())`.
4. Confirm the resulting package set matches the working DLAMI venv, then run the feature sweep (server boot + inference) on that set: segmented prefill, automatic prefix caching (hit counter), structured outputs, tool calling — plus the broader sweep used for the beta (GPT-OSS 20B BF16 MoE, EAGLE3 speculative decoding, Qwen3-VL multimodal).
5. Confirm the APC guard exists on this branch:
   `grep -n "Automatic Prefix Caching (APC) requires segmented prefill" vllm_neuron/vllm/worker/neuron_model_runner.py`.

## Test Result

1. Zero `.py` references anywhere in site-packages (incl. `neuronxcc`, `torch_xla`).
2. Unset -> `~/.cache/vllm/neuron/compile_cache`; `VLLM_CACHE_ROOT=/tmp/x` -> `/tmp/x/neuron/compile_cache`. Setting `NEURON_COMPILED_ARTIFACTS` did not change the output dir.
3. On a clean Python 3.12 venv, `pip install -e . --extra-index-url=https://pip.repos.neuron.amazonaws.com` completed with no dependency conflict: `torch` stayed at `2.11.0+cu130` (the added `libtorch-neuronx-lite==2.11.*` did not pull `torch-neuronx`, which would have downgraded torch to 2.9), `import nki` succeeded (`nki 0.5.0`), and `get_models()` returned `['LlamaForCausalLM', 'GptOssForCausalLM', 'Eagle3LlamaForCausalLM', 'Qwen3VLForConditionalGeneration']`. Before this change the same import raised `ModuleNotFoundError: No module named 'nki'`.
4. The resulting package set (`torch 2.11.0+cu130`, `nki 0.5.0`, `neuronx-cc 2.26`, `libtorch-neuronx-lite 2.11.0`) is identical to the v0.21 DLAMI venv on which the full feature sweep was validated, so the added deps induce no new runtime error. On that set the server boots and: segmented prefill PASS (multi-segment prompt, correct answer), structured outputs + tool calling PASS, automatic prefix caching functional (cache-hit counter increments). The broader beta sweep on the same set also passed: GPT-OSS 20B BF16 MoE, EAGLE3 speculative decoding, and Qwen3-VL multimodal. No behavioral regression relative to the DLAMI venv.
5. The guard is present at L669 on `release-0.21.0.1.0.0`; prefix caching produces correct, deterministic output in practice.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update — this PR includes the documentation update.
</details>