### PR TITLE
Add MiMo-V2.5 text decoder (BF16, TP64/EP64)

### DIFF
--- a/examples/vllm_neuron/models/mimo_v2_5/bench.sh
+++ b/examples/vllm_neuron/models/mimo_v2_5/bench.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Benchmark MiMo-V2.5 on this vllm-neuron port with `vllm bench serve`.
+#
+# Deliberately mirrors the recipe behind PR148's published Trn2 numbers --
+# 900-token input / 90-token output, random dataset, range ratio 0.03, TP=64
+# with EP=64 -- so output throughput / TTFT / TPOT line up column for column
+# against both the NxDI table and the 8xH100 SGLang/vLLM baselines.
+#
+# One difference is itself a result: PR148 could not measure BS=1 on the FP8
+# path at all, because NxDI's TKG rejects expert parallelism below
+# BS = n_routed_experts/top_k = 256/8 = 32. This port drives the NKI moe_cte /
+# moe_tkg kernels directly rather than ExpertMLPsV2.forward_selective_loading,
+# so BS=1 works and single-stream latency is measurable here.
+#
+# Assumes a server is ALREADY running and serving --served-model-name MiMo-V2.5
+# (see serve_mimo.sh). It is kept separate because the NEFF shape is baked per
+# (max_num_seqs, max_model_len): changing BS means restarting + recompiling the
+# server, so the bench driver must not own the server lifecycle.
+#
+# Usage:
+#   bash bench.sh                      # c=1,16,32 against the running server
+#   CONCURRENCIES="1 8" bash bench.sh
+set -u
+
+PORT="${PORT:-8000}"
+MODEL="${MODEL:-MiMo-V2.5}"
+# --model is the *served alias* that goes into the request payload, and the
+# driver also feeds it to AutoTokenizer to synthesize the random dataset -- where
+# an alias is not resolvable ("MiMo-V2.5 is not a local folder and is not a valid
+# model identifier"). So point --tokenizer at the checkpoint on disk explicitly.
+TOKENIZER="${TOKENIZER:-/opt/dlami/nvme/models/MiMo-V2.5-text}"
+INPUT_LEN="${INPUT_LEN:-900}"
+OUTPUT_LEN="${OUTPUT_LEN:-90}"
+RANGE_RATIO="${RANGE_RATIO:-0.03}"
+CONCURRENCIES="${CONCURRENCIES:-1 16 32}"
+TAG="${TAG:-bs32}"
+RESULTS_DIR="${RESULTS_DIR:-/opt/dlami/nvme/mimo_logs/bench}"
+VENV="${VENV:-/opt/aws_neuronx_venv_pytorch_inference_vllm_0_21_0_1_0_0}"
+
+mkdir -p "$RESULTS_DIR"
+
+if ! curl -s -m 5 "http://localhost:$PORT/health" > /dev/null; then
+    echo "ERROR: no healthy server on port $PORT. Start serve_mimo.sh first." >&2
+    exit 1
+fi
+
+for c in $CONCURRENCIES; do
+    # 16 prompts at c=1 keeps the single-stream pass short; 128 at higher
+    # concurrency gives every slot enough requests to reach steady state
+    # (same prompt counts PR148 used, so the comparison stays apples-to-apples).
+    if [ "$c" -eq 1 ]; then n=16; else n=128; fi
+    out="$RESULTS_DIR/${TAG}_c${c}.log"
+    echo "=== concurrency=$c prompts=$n -> $out"
+    PATH="$VENV/bin:$PATH" \
+    "$VENV/bin/vllm" bench serve \
+        --backend openai \
+        --model "$MODEL" \
+        --tokenizer "$TOKENIZER" \
+        --trust-remote-code \
+        --base-url "http://localhost:$PORT" \
+        --dataset-name random \
+        --random-input-len "$INPUT_LEN" \
+        --random-output-len "$OUTPUT_LEN" \
+        --random-range-ratio "$RANGE_RATIO" \
+        --num-prompts "$n" \
+        --max-concurrency "$c" \
+        --ignore-eos \
+        --percentile-metrics ttft,tpot,itl,e2el \
+        --save-result --result-dir "$RESULTS_DIR" \
+        --result-filename "${TAG}_c${c}.json" \
+        2>&1 | tee "$out" | grep -E \
+        'Successful|Benchmark duration|Output token throughput|Total Token|Mean TTFT|Median TTFT|P99 TTFT|Mean TPOT|Median TPOT|Median ITL'
+    echo
+done
+
+echo "Results in $RESULTS_DIR"

--- a/examples/vllm_neuron/models/mimo_v2_5/bench.sh
+++ b/examples/vllm_neuron/models/mimo_v2_5/bench.sh
@@ -27,14 +27,15 @@ MODEL="${MODEL:-MiMo-V2.5}"
 # --model is the *served alias* that goes into the request payload, and the
 # driver also feeds it to AutoTokenizer to synthesize the random dataset -- where
 # an alias is not resolvable ("MiMo-V2.5 is not a local folder and is not a valid
-# model identifier"). So point --tokenizer at the checkpoint on disk explicitly.
-TOKENIZER="${TOKENIZER:-/opt/dlami/nvme/models/MiMo-V2.5-text}"
+# model identifier"). So name the tokenizer source explicitly: a hub repo ID (the
+# default, cached in HF_HOME) or the local checkpoint the server is reading.
+TOKENIZER="${TOKENIZER:-XiaomiMiMo/MiMo-V2.5}"
 INPUT_LEN="${INPUT_LEN:-900}"
 OUTPUT_LEN="${OUTPUT_LEN:-90}"
 RANGE_RATIO="${RANGE_RATIO:-0.03}"
 CONCURRENCIES="${CONCURRENCIES:-1 16 32}"
 TAG="${TAG:-bs32}"
-RESULTS_DIR="${RESULTS_DIR:-/opt/dlami/nvme/mimo_logs/bench}"
+RESULTS_DIR="${RESULTS_DIR:-./mimo_bench_results}"
 VENV="${VENV:-/opt/aws_neuronx_venv_pytorch_inference_vllm_0_21_0_1_0_0}"
 
 mkdir -p "$RESULTS_DIR"

--- a/examples/vllm_neuron/models/mimo_v2_5/run.py
+++ b/examples/vllm_neuron/models/mimo_v2_5/run.py
@@ -16,8 +16,14 @@ NeuronCores) with ``enable_expert_parallel`` and ``ep_degree=64``, giving
 tp_sub = 64/64 = 1 (pure EP) and 4 experts per rank. 64 Q heads divide evenly
 by 64; the 4-and-8 KV head counts are replicated across ranks.
 
-      python examples/vllm_neuron/models/mimo_v2_5/run.py \
-      --model-checkpoint /opt/dlami/nvme/models/MiMo-V2.5-HF
+      python examples/vllm_neuron/models/mimo_v2_5/run.py
+
+Defaults to the public ``XiaomiMiMo/MiMo-V2.5`` repo (~294 GiB, downloaded to
+HF_HOME on first use). Pass ``--model-checkpoint`` a local path to reuse an
+existing copy. The vision/audio towers are not built by this port, so
+``assets/``, ``audio_tokenizer/`` and ``preprocessor_config.json`` are dead
+weight in a text-only download -- see serve_mimo.sh for an allow-listed
+``hf download`` that skips them.
 
 Attention runs eager (fp32 scores), not through a fused kernel: MiMo's 192-wide
 Q/K heads exceed the 128 head_dim cap in flash_attention / attention_decode /
@@ -63,8 +69,10 @@ def main():
     parser.add_argument(
         "--model-checkpoint",
         type=str,
-        default="/opt/dlami/nvme/models/MiMo-V2.5-HF",
-        help="Path to the HF checkpoint (FP8 on disk; dequantized at load time).",
+        default="XiaomiMiMo/MiMo-V2.5",
+        help="Hub repo ID or local path to the HF checkpoint (FP8 on disk; "
+        "dequantized at load time). Passed through to vLLM unchanged, so a "
+        "hub ID downloads to HF_HOME on first use.",
     )
     parser.add_argument("--tensor-parallel-size", type=int, default=64)
     parser.add_argument("--ep-degree", type=int, default=64)

--- a/examples/vllm_neuron/models/mimo_v2_5/run.py
+++ b/examples/vllm_neuron/models/mimo_v2_5/run.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline inference example for MiMo-V2.5 (mimo_v2_5).
+
+48 layers / hidden 4096 / 256 experts top-8, hybrid attention: 9 full-attention
+layers (0, 5, 11, 17, 23, 29, 35, 41, 47) and 39 sliding-window layers
+(window 128). Asymmetric head dims (Q/K 192, V 128) and asymmetric KV heads
+(full 4, SWA 8).
+
+Runtime is BF16. The released checkpoint stores its matmul weights as 128x128
+blockwise FP8-e4m3 with ``*.weight_scale_inv`` companions; the weight loaders
+dequantize host-side at load time, so NO separate BF16 conversion pass is
+needed -- point ``--model-checkpoint`` straight at the HF checkpoint.
+
+EP config: ``tensor_parallel_size=64`` (the full trn2.48xlarge: 16 devices x 4
+NeuronCores) with ``enable_expert_parallel`` and ``ep_degree=64``, giving
+tp_sub = 64/64 = 1 (pure EP) and 4 experts per rank. 64 Q heads divide evenly
+by 64; the 4-and-8 KV head counts are replicated across ranks.
+
+      python examples/vllm_neuron/models/mimo_v2_5/run.py \
+      --model-checkpoint /opt/dlami/nvme/models/MiMo-V2.5-HF
+
+Attention runs eager (fp32 scores), not through a fused kernel: MiMo's 192-wide
+Q/K heads exceed the 128 head_dim cap in flash_attention / attention_decode /
+segmented_attention. The MoE does use the NKI kernels (moe_cte for prefill,
+moe_tkg for decode).
+"""
+
+import argparse
+
+from vllm import LLM, SamplingParams
+
+
+def _text_only_overrides(config):
+    """Drop the config keys that would route this text port elsewhere.
+
+    Both keys must be DELETED, not set to None:
+
+    * ``quantization_config`` -- vLLM derives ``ModelConfig.quantization`` from
+      its ``quant_method`` and then checks it against
+      ``NeuronPlatform.supported_quantization``, which does not list "fp8", so
+      startup aborts before the model is built. The FP8 bytes never reach the
+      framework's quant machinery: this port's weight loaders dequantize to bf16
+      on the host, and they pick their branch by probing the checkpoint for
+      ``*_scale_inv`` keys (``MiMoV2ForCausalLM._detect_quantized``), not by
+      reading this config.
+    * ``vision_config`` -- vLLM's ``MimoV2ModelArchConfigConvertor`` rewrites
+      ``architectures`` to ``["MiMoV2OmniForCausalLM"]`` whenever a vision config
+      is present, routing past this port's registry entry. And
+      ``NeuronPlatform.check_and_update_config`` gates the vision path on
+      ``hasattr(hf_config, "vision_config")``, so a None-valued attribute still
+      builds a ``vision_neuron_config`` and sends ``load_model`` down the
+      multimodal ``from_configs(text_neuron_config=..., vision_neuron_config=...)``
+      branch. Only ``delattr`` clears both checks.
+    """
+    for key in ("quantization_config", "vision_config"):
+        if hasattr(config, key):
+            delattr(config, key)
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model-checkpoint",
+        type=str,
+        default="/opt/dlami/nvme/models/MiMo-V2.5-HF",
+        help="Path to the HF checkpoint (FP8 on disk; dequantized at load time).",
+    )
+    parser.add_argument("--tensor-parallel-size", type=int, default=64)
+    parser.add_argument("--ep-degree", type=int, default=64)
+    parser.add_argument("--max-model-len", type=int, default=512)
+    parser.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=1,
+        help="Max concurrent sequences. bs=1 is the bringup path.",
+    )
+    parser.add_argument(
+        "--prompts",
+        type=str,
+        default=None,
+        help="'@@'-separated prompt list overriding the defaults.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument(
+        "--prefill-bucket",
+        type=int,
+        default=None,
+        help=(
+            "Prefill token bucket, i.e. num_batched_tokens_buckets. Defaults to "
+            "--max-model-len (single-shot prefill of the whole window). Setting "
+            "it smaller decouples the prefill graph's token count from the "
+            "KV-cache/block-table sizing, which is how the SEQ=1024 warmup "
+            "fault was localized."
+        ),
+    )
+    parser.add_argument(
+        "--chat",
+        action="store_true",
+        help=(
+            "Wrap each prompt in the checkpoint's chat template instead of "
+            "feeding it as a raw completion. MiMo-V2.5 is instruction/thinking "
+            "tuned, so raw continuations drift into reasoning-mode text and are "
+            "not a fair coherence check; use this to exercise it as intended."
+        ),
+    )
+    parser.add_argument(
+        "--thinking",
+        action="store_true",
+        help=(
+            "With --chat, leave the template's reasoning mode on. Off by "
+            "default because the template defaults enable_thinking=True, which "
+            "spends the whole token budget inside the reasoning block and "
+            "leaves the visible answer empty at small --max-tokens."
+        ),
+    )
+    args = parser.parse_args()
+
+    # The runner requires the last prefill bucket to equal max_num_batched_tokens,
+    # so shrinking the prefill graph means lowering that cap too -- which is
+    # exactly the point: KV cache and block tables stay sized by max_model_len
+    # while the prefill NEFF traces fewer tokens.
+    prefill_bucket = args.prefill_bucket or args.max_model_len
+
+    llm = LLM(
+        model=args.model_checkpoint,
+        max_model_len=args.max_model_len,
+        max_num_batched_tokens=prefill_bucket,
+        max_num_seqs=args.max_num_seqs,
+        tensor_parallel_size=args.tensor_parallel_size,
+        enable_expert_parallel=True,
+        # APC is on by default in vLLM V1, and the Neuron runner only supports it
+        # alongside segmented prefill (max_num_batched_tokens in
+        # {512, 1024, ...}). This port prefills single-shot, so turn APC off.
+        enable_prefix_caching=False,
+        # MiMo ships its config/modeling as custom repo code (model_type
+        # "mimo_v2" is not in upstream transformers), so HF needs this to build
+        # the PretrainedConfig that MiMoV2Config.from_configs consumes.
+        trust_remote_code=True,
+        # Strip the quant/vision config keys; see _text_only_overrides.
+        hf_overrides=_text_only_overrides,
+        # The released checkpoint is multimodal (vision/audio sub-configs); this
+        # port covers the TEXT decoder, so zero out the per-prompt mm limits so
+        # the runner does not demand a vision_neuron_config.
+        limit_mm_per_prompt={"image": 0, "video": 0, "audio": 0},
+        additional_config={
+            "neuron_config": {
+                # BF16 runtime; the FP8 disk format is handled by the loaders.
+                "quantization": "bf16",
+                "ep_degree": args.ep_degree,
+                "num_batched_tokens_buckets": [prefill_bucket],
+                "num_seqs_buckets": [args.max_num_seqs],
+                "on_device_sampling_config": {"all_greedy": "true"},
+            }
+        },
+    )
+
+    if args.prompts:
+        prompts = args.prompts.split("@@")
+    else:
+        prompts = [
+            "The capital of France is",
+            "1 2 3 4 5 6 7 8 9",
+            "Once upon a time, there was a",
+            "def fibonacci(n):",
+        ]
+    sampling_params = SamplingParams(
+        max_tokens=args.max_tokens, temperature=0.0, top_p=1.0
+    )
+
+    if args.chat:
+        tok = llm.get_tokenizer()
+        rendered = [
+            tok.apply_chat_template(
+                [{"role": "user", "content": p}],
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=args.thinking,
+            )
+            for p in prompts
+        ]
+        outputs = llm.generate(rendered, sampling_params)
+    else:
+        outputs = llm.generate(prompts, sampling_params)
+
+    for src, o in zip(prompts, outputs):
+        print(repr(src), "->", repr(o.outputs[0].text))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
+++ b/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
@@ -14,13 +14,25 @@
 # SEQ forces a fresh compile (~5-10 min). Keep them as env knobs rather than
 # editing inline, and let bench.sh drive load against an already-warm server.
 #
+# MODEL takes a hub repo ID or a local path -- vllm resolves either. The default
+# pulls the public checkpoint (~294 GiB) into HF_HOME on first start, which makes
+# the first launch look like it is hanging before compilation even begins. To
+# fetch only what a text-only server reads (skipping the vision/audio assets this
+# port never builds) and serve from disk instead:
+#
+#   hf download XiaomiMiMo/MiMo-V2.5 --local-dir ./MiMo-V2.5 \
+#       --include 'config.json' 'configuration_mimo_v2.py' 'modeling_mimo_v2.py' \
+#                 'generation_config.json' 'tokenizer*' 'vocab.json' 'merges.txt' \
+#                 'model*.safetensors' 'model.safetensors.index.json'
+#   MODEL=./MiMo-V2.5 bash serve_mimo.sh
+#
 # Usage:
 #   bash serve_mimo.sh                 # BS=32, SEQ=1024
 #   BS=1 SEQ=512 bash serve_mimo.sh
 
 set -x
 
-MODEL="${MODEL:-/opt/dlami/nvme/models/MiMo-V2.5-text}"
+MODEL="${MODEL:-XiaomiMiMo/MiMo-V2.5}"
 BS="${BS:-32}"
 SEQ="${SEQ:-1024}"
 PORT="${PORT:-8000}"

--- a/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
+++ b/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# MiMo-V2.5 single-instance server — TP64 with expert parallelism, BF16.
+#
+# 48 layers / 256 routed experts / top-8 / hidden 4096. At TP=64 with EP=64 each
+# rank owns 4 experts, which is what the MoE kernels are sized against below.
+#
+# Text decoder only. The released checkpoint is multimodal, and its custom
+# configuration_mimo_v2.py sets self.vision_config unconditionally, so
+# --limit-mm-per-prompt pins every modality to 0 to keep the vision tower out of
+# bucket sizing (see MiMoV2ForCausalLM.from_configs and
+# NeuronPlatform._mm_disabled for why that is load-bearing rather than cosmetic).
+#
+# The NEFF cache key bakes in (max_num_seqs, max_model_len), so changing BS or
+# SEQ forces a fresh compile (~5-10 min). Keep them as env knobs rather than
+# editing inline, and let bench.sh drive load against an already-warm server.
+#
+# Usage:
+#   bash serve_mimo.sh                 # BS=32, SEQ=1024
+#   BS=1 SEQ=512 bash serve_mimo.sh
+
+set -x
+
+MODEL="${MODEL:-/opt/dlami/nvme/models/MiMo-V2.5-text}"
+BS="${BS:-32}"
+SEQ="${SEQ:-1024}"
+PORT="${PORT:-8000}"
+
+# Mandatory on this instance: the Neuron runtime otherwise probes for an EFA
+# device per rank and every rank dies with "No EFA device found at
+# /sys/bus/pci/devices/.../infiniband".
+export NEURON_SKIP_EFA_AFFINITY=1
+
+echo "Starting MiMo-V2.5 server: $MODEL (BS=$BS, SEQ=$SEQ, TP=64, EP=64)"
+
+vllm serve "$MODEL" \
+    --served-model-name MiMo-V2.5 \
+    --max-model-len "$SEQ" \
+    --max-num-seqs "$BS" \
+    --tensor-parallel-size 64 \
+    --enable-expert-parallel \
+    --no-enable-prefix-caching \
+    --trust-remote-code \
+    --limit-mm-per-prompt '{"image":0,"video":0,"audio":0}' \
+    --additional-config "{
+        \"neuron_config\": {
+            \"quantization\": \"bf16\",
+            \"ep_degree\": 64,
+            \"num_batched_tokens_buckets\": [$SEQ],
+            \"num_seqs_buckets\": [$BS],
+            \"on_device_sampling_config\": {\"all_greedy\": \"true\"}
+        }
+    }" \
+    --port "$PORT"

--- a/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
+++ b/examples/vllm_neuron/models/mimo_v2_5/serve_mimo.sh
@@ -26,6 +26,12 @@
 #                 'model*.safetensors' 'model.safetensors.index.json'
 #   MODEL=./MiMo-V2.5 bash serve_mimo.sh
 #
+# --max-num-batched-tokens must be passed explicitly: it does NOT follow
+# --max-model-len, it defaults to 2048, and validate_num_batched_tokens_buckets
+# requires the last num_batched_tokens_bucket to equal it. Without it any
+# SEQ > 2048 dies at startup with "Last bucket in num_batched_tokens_buckets
+# must equal max_num_batched_tokens (2048)".
+#
 # Usage:
 #   bash serve_mimo.sh                 # BS=32, SEQ=1024
 #   BS=1 SEQ=512 bash serve_mimo.sh
@@ -48,6 +54,7 @@ vllm serve "$MODEL" \
     --served-model-name MiMo-V2.5 \
     --max-model-len "$SEQ" \
     --max-num-seqs "$BS" \
+    --max-num-batched-tokens "$SEQ" \
     --tensor-parallel-size 64 \
     --enable-expert-parallel \
     --no-enable-prefix-caching \

--- a/vllm_neuron/functional/__init__.py
+++ b/vllm_neuron/functional/__init__.py
@@ -6,6 +6,7 @@ from .spec_decode_correction import (
 from .attention.attention_decode_mask import gen_attention_decode_mask
 from .attention.attention_decode import attention_decode
 from .attention.qkv import qkv_proj
+from .attention.kv_cache_write import write_paged_kv_cache
 from .attention.o_proj import o_proj
 from .attention.attention_cte import flash_attention
 from .attention.attention_segmented_cte import (
@@ -71,4 +72,5 @@ __all__ = [
     "segmented_attention_cp",
     "topk_reduce",
     "validate_expert_parallelism_config",
+    "write_paged_kv_cache",
 ]

--- a/vllm_neuron/functional/attention/kv_cache_write.py
+++ b/vllm_neuron/functional/attention/kv_cache_write.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-place paged KV-cache scatter for models without a fused attention kernel.
+
+``Tensor.index_put_`` on a cache parameter is not an in-place write under
+neuronx-cc: XLA has no in-place scatter, so it lowers to a full-tensor
+``scatter`` that materializes a fresh copy of the ENTIRE cache pool (plus, in
+practice, an identity ``transpose`` the compiler fails to elide). Writing one
+token's 384 bytes of K therefore costs reads and writes of the whole pool.
+
+The FX aliasing pass can rewrite the LAST write per cache parameter into a true
+in-place update, but vLLM hands the same raw cache tensor to several layers at
+once (``for layer_name in tensor.shared_by`` in ``initialize_kv_cache``), so
+those layers' writes chain on one placeholder and every intermediate copy
+survives. On MiMo-V2.5 that is 96 writes over 18 buffers -- ~124 GB of pool
+traffic per decode step.
+
+This kernel sidesteps the lowering: it DMAs the new rows straight into the cache
+buffer with an indirect (``vector_offset``) scatter, and RETURNS the cache
+tensors so the NKI compiler reports ``operand_output_aliases``. That puts the
+write on the aliasing pass's NKI path, which chains ``k0 -> k1 -> ... -> kN``
+across every write to a shared buffer instead of only aliasing the last one.
+
+Models whose head dim fits the fused kernel's 128 cap should keep using
+``NF.attention_decode(update_cache=True)``; this exists for the eager-attention
+models (e.g. MiMo's 192-wide Q/K) that the fused path rejects.
+"""
+
+import os
+
+import torch
+from torch import Tensor
+
+import nki
+import nki.isa as nisa
+import nki.language as nl
+from nki.isa.constants import oob_mode
+from nkilib.core.utils.kernel_helpers import get_verified_program_sharding_info
+
+from vllm_neuron.nki.nki_hop import can_run_kernel, wrap_nki
+
+# Row index meaning "drop this row". ``oob_mode.skip`` discards indirect-DMA
+# offsets that land outside the destination, and int32 max exceeds any real
+# cache row count by orders of magnitude, so padding / freed slots
+# (``slot_mapping < 0``) are mapped to it. Kept inside int32 so the index
+# tensor needs no unsigned dtype, which the torch device layer handles poorly.
+_SKIP_ROW = 0x7FFFFFFF
+
+
+def _scatter_rows(cache_flat, new_rows, idx_tile, start, tile_n, d):
+    """Stage one tile of ``new_rows`` into SBUF, then indirect-DMA it to *cache_flat*.
+
+    Factored out and called twice rather than looped over ``(k, v)`` pairs
+    because NKI's parser rejects tuple unpacking in a ``for`` target
+    ("expecting simple variable").
+    """
+    tile = nl.ndarray((tile_n, d), dtype=new_rows.dtype, buffer=nl.sbuf)
+    nisa.dma_copy(tile, new_rows[nl.ds(start, tile_n), :])
+    nisa.dma_copy(
+        dst=cache_flat.ap(
+            pattern=[[d, tile_n], [1, d]],
+            offset=0,
+            vector_offset=idx_tile,
+            indirect_dim=0,
+        ),
+        src=tile,
+        oob_mode=oob_mode.skip,
+    )
+
+
+@nki.jit
+def _kv_cache_scatter_kernel(
+    k_cache: Tensor,
+    v_cache: Tensor,
+    k_new: Tensor,
+    v_new: Tensor,
+    row_idx: Tensor,
+):
+    """Scatter ``k_new``/``v_new`` into the K/V caches at rows ``row_idx``.
+
+    The caches arrive 4D and are flattened HERE rather than by the caller: the
+    aliasing pass only rewires a write whose FX shape matches the placeholder
+    exactly, so a pre-call ``reshape`` would silently disable the write-chain
+    serialization this kernel exists to enable.
+
+    Args:
+        k_cache: ``[num_blocks, num_kv_heads, block_size, d]``, written in place.
+        v_cache: Same shape as *k_cache*.
+        k_new: ``[N, d]`` rows to write.
+        v_new: ``[N, d]`` rows to write.
+        row_idx: ``[N, 1]`` destination row in the (block, head, position)
+            flattening; ``_SKIP_ROW`` drops the row.
+
+    Returns:
+        ``(k_cache, v_cache)``. Returning them is what makes the NKI compiler
+        emit ``operand_output_aliases`` -- a kernel that writes an input but
+        returns nothing reports no aliases AND no outputs, so the write is
+        dropped from the graph entirely.
+    """
+    _, n_prgs, prg_id = get_verified_program_sharding_info("kv_cache_write", (0, 1), 2)
+
+    num_blocks = k_cache.shape[0]
+    nkh = k_cache.shape[1]
+    blk = k_cache.shape[2]
+    d = k_cache.shape[3]
+    n_rows = k_new.shape[0]
+
+    k_flat = k_cache.reshape((num_blocks * nkh * blk, d))
+    v_flat = v_cache.reshape((num_blocks * nkh * blk, d))
+
+    tile_sz = nl.tile_size.pmax
+    for start in range(0, n_rows, tile_sz):
+        tile_n = min(tile_sz, n_rows - start)
+
+        idx_tile = nl.ndarray((tile_n, 1), dtype=row_idx.dtype, buffer=nl.sbuf)
+        nisa.dma_copy(idx_tile, row_idx[nl.ds(start, tile_n)])
+
+        # Split K and V across the two logical cores (same split
+        # ``_update_block_cache_vectorized`` uses) so the two scatters overlap.
+        if n_prgs == 1 or prg_id == 0:
+            _scatter_rows(v_flat, v_new, idx_tile, start, tile_n, d)
+        if n_prgs == 1 or prg_id == 1:
+            _scatter_rows(k_flat, k_new, idx_tile, start, tile_n, d)
+
+    return k_cache, v_cache
+
+
+def _can_use_kernel(k_cache: Tensor, v_cache: Tensor, k: Tensor) -> bool:
+    """Whether the NKI scatter applies; otherwise fall back to ``index_put_``."""
+    if not can_run_kernel(k):
+        return False
+
+    # Diagnostic escape hatch: force the (functionally equivalent, far slower)
+    # index_put_ write. Narrower than VLLM_NEURON_DISABLE_NKI_KERNELS, which
+    # would also drop the MoE/attention kernels -- this isolates "is a wrong
+    # answer coming from the cache write, or from somewhere else?" while leaving
+    # the rest of the model on its normal path.
+    if os.environ.get("VLLM_NEURON_KV_WRITE_FORCE_TORCH") == "1":
+        return False
+
+    # The scatter itself is dtype-agnostic (it moves whole rows), but the SBUF
+    # staging tile is typed. Restrict to the float types this is exercised
+    # with; FP8 caches use a packed layout that needs read-modify-write.
+    if k_cache.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        return False
+    if k_cache.dtype != v_cache.dtype or k.dtype != k_cache.dtype:
+        return False
+
+    # Both caches must be the canonical 4D paged buffer of the same shape, so
+    # one row index serves both.
+    if k_cache.dim() != 4 or k_cache.shape != v_cache.shape:
+        return False
+
+    return True
+
+
+def write_paged_kv_cache(
+    k_cache: Tensor,
+    v_cache: Tensor,
+    k: Tensor,
+    v: Tensor,
+    slot_mapping: Tensor,
+    block_size: int,
+    num_kv_heads: int,
+) -> tuple[Tensor, Tensor]:
+    """Write post-RoPE K/V into a paged KV cache at ``slot_mapping``.
+
+    ``k``/``v`` are ``[num_kv_heads * n_tokens, d]`` in HEAD-MAJOR order (head
+    0's tokens, then head 1's, ...), i.e. what ``[nkh, T, d].reshape(-1, d)``
+    gives. Both must already be at the cache's width and dtype: padding V from
+    ``v_head_dim`` up to a shared cache ``head_size`` is the caller's job, since
+    only the caller knows the two widths.
+
+    Args:
+        k_cache: ``[num_blocks, num_kv_heads, block_size, d]``, written in place.
+        v_cache: Same shape as *k_cache*.
+        k: ``[num_kv_heads * n_tokens, d]`` rows to write.
+        v: ``[num_kv_heads * n_tokens, d]`` rows to write.
+        slot_mapping: ``[n_tokens]`` global slot per token; negative entries
+            (padding / freed rows) are dropped.
+        block_size: Slots per block.
+        num_kv_heads: KV heads held by this rank.
+
+    Returns:
+        ``(k_cache, v_cache)``. On the kernel path these are the kernel's
+        aliased outputs; callers MUST rebind their cache references to them so
+        the aliasing pass can thread the write through to downstream readers.
+    """
+    n_tokens = slot_mapping.shape[0]
+
+    if not _can_use_kernel(k_cache, v_cache, k):
+        # ``index_put_`` mutates in place, so returning the inputs gives this
+        # path the same contract as the kernel's.
+        block_indices = (slot_mapping // block_size).repeat(num_kv_heads)
+        position_indices = (slot_mapping % block_size).repeat(num_kv_heads)
+        head_indices = torch.arange(
+            num_kv_heads, dtype=torch.long, device=k.device
+        ).repeat_interleave(n_tokens)
+        k_cache.index_put_((block_indices, head_indices, position_indices), k)
+        v_cache.index_put_((block_indices, head_indices, position_indices), v)
+        return k_cache, v_cache
+
+    _, nkh, blk, _ = k_cache.shape
+
+    # Flat row in the (block, head, position) flattening:
+    #   row = block * (nkh * blk) + head * blk + pos
+    # slot_mapping is (block * block_size + pos) in a head-independent frame, so
+    # split it before re-weighting the block stride by nkh.
+    slots = slot_mapping.to(torch.int32)
+    base = (slots // block_size) * (nkh * blk) + (slots % block_size)
+    head_stride = (
+        torch.arange(nkh, dtype=torch.int32, device=slots.device) * blk
+    ).repeat_interleave(n_tokens)  # head-major, matching k/v row order
+    rows = base.repeat(nkh) + head_stride
+
+    # Negative slots are padding / freed rows. Redirect them to the skip
+    # sentinel; left alone, the divmod above would fold them onto a live row.
+    rows = torch.where(
+        slots.repeat(nkh) < 0, torch.full_like(rows, _SKIP_ROW), rows
+    )
+
+    wrapped = wrap_nki(_kv_cache_scatter_kernel)
+    return wrapped[2](
+        k_cache=k_cache,
+        v_cache=v_cache,
+        k_new=k,
+        v_new=v,
+        row_idx=rows.view(-1, 1),
+    )

--- a/vllm_neuron/functional/moe/moe_blockwise.py
+++ b/vllm_neuron/functional/moe/moe_blockwise.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import math
+import os
 import torch
 import torch.distributed as dist
 from torch import Tensor
@@ -116,6 +117,11 @@ def build_blockwise_mapping(
         f_len=f_len,
     )
     use_kernel_flow = can_use_find_nonzero_kernel and can_use_indexed_flatten_kernel
+    # Diagnostic escape hatch: the torch fallback is functionally equivalent, so
+    # forcing it isolates "is the DGE mapping kernel at fault?" from the rest of
+    # the MoE dispatch. Set VLLM_NEURON_MOE_MAPPING_FORCE_TORCH=1 to use it.
+    if os.environ.get("VLLM_NEURON_MOE_MAPPING_FORCE_TORCH") == "1":
+        use_kernel_flow = False
 
     if use_kernel_flow:
         token_position_to_id, block_to_expert, num_blocks = (

--- a/vllm_neuron/functional/moe/moe_cte.py
+++ b/vllm_neuron/functional/moe/moe_cte.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+import os
+
 import nki
 import torch
 import nki.language as nl
@@ -591,6 +593,13 @@ def _can_use_moe_cte_kernel(
     I_TP = gate_up_proj_weight.shape[-1]
 
     if I_TP < 128:
+        return False
+
+    # Diagnostic escape hatch: force the (functionally equivalent, much slower)
+    # torch MoE compute. Isolates "does the fault come from the MoE dispatch
+    # kernel or from somewhere else in the layer?" -- the mapping-kernel hatch in
+    # moe_blockwise.py already showed the mapping itself is not at fault.
+    if os.environ.get("VLLM_NEURON_MOE_CTE_FORCE_TORCH") == "1":
         return False
 
     if implementation in [

--- a/vllm_neuron/model/mimo_v2_5/__init__.py
+++ b/vllm_neuron/model/mimo_v2_5/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from . import model  # noqa: F401
+from .config import MiMoV2Config
+from .factory import MiMoV2ForCausalLM
+from .weight_loaders_bf16 import (
+    dense_down_fp8_loader,
+    dense_gate_up_fp8_loader,
+    dequant_fp8_blockwise,
+    expert_down_fp8_loader,
+    expert_gate_up_fp8_loader,
+    fused_qkv_fp8_loader,
+    infer_qkv_disk_tp,
+    qkv_disk_tp_candidates,
+)
+
+__all__ = [
+    "MiMoV2Config",
+    "MiMoV2ForCausalLM",
+    "dense_down_fp8_loader",
+    "dense_gate_up_fp8_loader",
+    "dequant_fp8_blockwise",
+    "expert_down_fp8_loader",
+    "expert_gate_up_fp8_loader",
+    "fused_qkv_fp8_loader",
+    "infer_qkv_disk_tp",
+    "qkv_disk_tp_candidates",
+]

--- a/vllm_neuron/model/mimo_v2_5/config.py
+++ b/vllm_neuron/model/mimo_v2_5/config.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MiMo-V2.5 Config
+================
+
+Text-only decoder config for MiMoV2ForCausalLM (``model_type="mimo_v2"``).
+
+The released checkpoint is multimodal (it carries ``vision_config`` /
+``audio_config`` / ``processor_config`` plus a ``model.mtp.*`` MTP head), but
+this port covers the TEXT decoder only. The extra sub-configs are dropped by
+the ``field_names`` filter in :meth:`MiMoV2Config.from_configs`, and the
+corresponding checkpoint tensors are simply never referenced by
+``load_weights`` (``load_sharded_pipelined`` only pulls the keys the model's
+parameters map to).
+
+Architecture (48 layers, 256 experts, hidden 4096):
+  - HYBRID attention: ``hybrid_layer_pattern[i] == 0`` -> FULL attention,
+    ``== 1`` -> SWA (window 128). Note the polarity: 0 is full, and the full
+    layers are 0, 5, 11, 17, 23, 29, 35, 41, 47 (9 of 48).
+  - Asymmetric head dims: Q/K ``head_dim=192``, V ``v_head_dim=128``.
+  - Asymmetric KV heads: full layers 4 KV heads, SWA layers 8.
+  - Partial RoPE: ``rope_dim = int(head_dim * partial_rotary_factor) = 64``
+    (only the first 64 of 192 dims are rotated).
+  - Dual RoPE base: ``rope_theta=1e7`` on full layers,
+    ``swa_rope_theta=1e4`` on SWA layers.
+  - Attention sink bias on SWA layers ONLY (``add_swa_attention_sink_bias``),
+    one scalar per Q head (64 wide).
+  - ``attention_value_scale=0.707`` applied to V BEFORE the KV-cache write.
+  - MoE on layers 1..47 (``moe_layer_freq[0] == 0`` -> layer 0 is dense);
+    sigmoid router with ``noaux_tc`` group top-k selection.
+  - Plain RMSNorm (``weight * x``, no ``1 +`` fold), eps from
+    ``layernorm_epsilon``.
+"""
+
+import json
+from dataclasses import dataclass, field
+
+import torch
+from transformers import PretrainedConfig
+
+from vllm_neuron.model.neuron_config import NeuronConfig
+
+
+@dataclass
+class MiMoV2Config:
+    # ── Backbone ──────────────────────────────────────────────────────────
+    vocab_size: int = 152576
+    hidden_size: int = 4096
+    intermediate_size: int = 16384
+    num_hidden_layers: int = 48
+    max_position_embeddings: int = 1048576
+    hidden_act: str = "silu"
+    tie_word_embeddings: bool = False
+    torch_dtype: torch.dtype = torch.bfloat16
+
+    # HF spells the norm epsilon ``layernorm_epsilon`` (not ``rms_norm_eps``).
+    layernorm_epsilon: float = 1e-5
+
+    # ── Full attention geometry ───────────────────────────────────────────
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 4
+    head_dim: int = 192
+    v_head_dim: int = 128
+
+    # ── SWA attention geometry ────────────────────────────────────────────
+    swa_num_attention_heads: int = 64
+    swa_num_key_value_heads: int = 8
+    swa_head_dim: int = 192
+    swa_v_head_dim: int = 128
+    sliding_window: int = 128
+
+    # ── Hybrid / RoPE / sink ──────────────────────────────────────────────
+    # 0 == FULL attention, 1 == SWA (see module docstring).
+    hybrid_layer_pattern: list[int] = field(default_factory=list)
+    partial_rotary_factor: float = 0.334
+    rope_theta: float = 1e7
+    swa_rope_theta: float = 1e4
+    attention_bias: bool = False
+    attention_value_scale: float = 0.707
+    add_full_attention_sink_bias: bool = False
+    add_swa_attention_sink_bias: bool = True
+
+    # ── MoE ───────────────────────────────────────────────────────────────
+    # moe_layer_freq[i] truthy -> layer i is MoE, else dense MLP.
+    moe_layer_freq: list[int] = field(default_factory=list)
+    moe_intermediate_size: int = 2048
+    n_routed_experts: int = 256
+    num_experts_per_tok: int = 8
+    n_shared_experts: int | None = None
+    n_group: int = 1
+    topk_group: int = 1
+    norm_topk_prob: bool = True
+    scoring_func: str = "sigmoid"
+    topk_method: str = "noaux_tc"
+    # HF stores ``null`` here and multiplies by 1.0; keep the same default.
+    routed_scaling_factor: float | None = None
+
+    # ── Framework ─────────────────────────────────────────────────────────
+    neuron_config: NeuronConfig | None = None
+
+    # The released base checkpoint is fp8-e4m3 blockwise (128x128) on disk with
+    # ``dtype: bfloat16`` as the COMPUTE dtype. The weight loaders dequantize to
+    # bf16 at load time, so runtime is pure BF16 and this field is informational
+    # (kept so ``from_configs`` does not choke on the HF key and so the loaders
+    # can read the block shape rather than hard-coding 128x128).
+    quantization_config: dict | None = None
+
+    # Shard count the fused-QKV weights are PRE-SHARDED into on disk (the
+    # checkpoint index's ``metadata.tp_size``; 4 for the released base model).
+    # This cannot be inferred from the SWA layers' shapes -- every section there
+    # is already 128-divisible, so disk_tp 1, 2 and 4 all yield 116 scale rows
+    # while laying the head rows out differently -- so it must be carried
+    # explicitly. ``None`` means "infer per tensor", which works only for a
+    # checkpoint whose every layer has a ceil-padded grid.
+    qkv_disk_tp: int | None = None
+
+    def __post_init__(self):
+        if not self.hybrid_layer_pattern:
+            # No pattern -> treat every layer as full attention.
+            self.hybrid_layer_pattern = [0] * self.num_hidden_layers
+        if not self.moe_layer_freq:
+            self.moe_layer_freq = [1] * self.num_hidden_layers
+        if len(self.hybrid_layer_pattern) != self.num_hidden_layers:
+            raise ValueError(
+                f"hybrid_layer_pattern has {len(self.hybrid_layer_pattern)} "
+                f"entries but num_hidden_layers={self.num_hidden_layers}"
+            )
+        if len(self.moe_layer_freq) != self.num_hidden_layers:
+            raise ValueError(
+                f"moe_layer_freq has {len(self.moe_layer_freq)} entries but "
+                f"num_hidden_layers={self.num_hidden_layers}"
+            )
+
+    # ── Derived helpers ───────────────────────────────────────────────────
+
+    @property
+    def rms_norm_eps(self) -> float:
+        """Alias so generic framework code can read the norm eps."""
+        return self.layernorm_epsilon
+
+    @property
+    def rope_dim(self) -> int:
+        """Rotated width of each head (64 for the released config).
+
+        HF: ``rope_dim = int(head_dim * partial_rotary_factor)``. Both the full
+        and SWA variants have ``head_dim == 192``, so one value serves both.
+        """
+        return int(self.head_dim * self.partial_rotary_factor)
+
+    @property
+    def swa_rope_dim(self) -> int:
+        return int(self.swa_head_dim * self.partial_rotary_factor)
+
+    def is_swa_layer(self, layer_idx: int) -> bool:
+        return self.hybrid_layer_pattern[layer_idx] == 1
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        return bool(self.moe_layer_freq[layer_idx])
+
+    @property
+    def weight_block_size(self) -> tuple[int, int]:
+        """FP8 blockwise quantization tile, ``(128, 128)`` for this release."""
+        qc = self.quantization_config or {}
+        wbs = qc.get("weight_block_size") or [128, 128]
+        return int(wbs[0]), int(wbs[1])
+
+    @property
+    def is_fp8_checkpoint(self) -> bool:
+        qc = self.quantization_config or {}
+        return qc.get("quant_method") == "fp8" and qc.get("store_dtype") == "fp8"
+
+    @property
+    def fp8_ignored_layers(self) -> set[str]:
+        """Module prefixes stored unquantized (bf16) despite the fp8 config.
+
+        For this release that is every ``self_attn.o_proj``.
+        """
+        qc = self.quantization_config or {}
+        return set(qc.get("ignored_layers") or [])
+
+    # ── Construction ──────────────────────────────────────────────────────
+
+    @classmethod
+    def from_configs(
+        cls, hf_config: PretrainedConfig | dict | str, neuron_config: NeuronConfig = None
+    ) -> "MiMoV2Config":
+        if isinstance(hf_config, (str, bytes)):
+            with open(hf_config) as f:
+                config_dict = json.load(f)
+        elif isinstance(hf_config, PretrainedConfig):
+            config_dict = hf_config.to_dict()
+            if getattr(hf_config, "torch_dtype", None) is not None:
+                config_dict["torch_dtype"] = hf_config.torch_dtype
+        else:
+            config_dict = dict(hf_config)
+
+        field_names = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in config_dict.items() if k in field_names}
+
+        # HF 4.57 writes the compute dtype under ``dtype``; older exports use
+        # ``torch_dtype``. Accept either.
+        if "torch_dtype" not in filtered and "dtype" in config_dict:
+            filtered["torch_dtype"] = config_dict["dtype"]
+        if isinstance(filtered.get("torch_dtype"), str):
+            filtered["torch_dtype"] = getattr(torch, filtered["torch_dtype"])
+
+        # ``sliding_window_size`` is the alias the released config also carries;
+        # prefer ``sliding_window`` but fall back so either spelling works.
+        if "sliding_window" not in filtered and "sliding_window_size" in config_dict:
+            filtered["sliding_window"] = config_dict["sliding_window_size"]
+
+        if neuron_config is not None:
+            filtered["neuron_config"] = neuron_config
+
+        return cls(**filtered)

--- a/vllm_neuron/model/mimo_v2_5/factory.py
+++ b/vllm_neuron/model/mimo_v2_5/factory.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory for MiMo-V2.5 implementation selection."""
+
+import torch.nn as nn
+from transformers import PretrainedConfig
+
+from vllm_neuron.compile.platform import get_platform_target
+from vllm_neuron.model.neuron_config import NeuronConfig
+
+
+class MiMoV2ForCausalLM(nn.Module):
+    """Validates the config and selects a MiMo-V2.5 implementation.
+
+    Extends ``nn.Module`` so vLLM's ``ModelRegistry`` accepts the entry. Only a
+    BF16 runtime exists today: the released checkpoint stores its matmul weights
+    as 128x128-blockwise FP8-e4m3 and the weight loaders dequantize to BF16
+    host-side at load time (see ``weight_loaders_bf16``), so both
+    ``quantization=None|"bf16"`` and ``quantization="fp8"`` land on the same
+    implementation. There is no on-device FP8 path: Neuron has no 128x128
+    blockwise-FP8 MoE kernel.
+    """
+
+    def __init__(
+        self, hf_config: PretrainedConfig, neuron_config: NeuronConfig | None
+    ) -> None:
+        super().__init__()
+        self._model = self._select_implementation(hf_config, neuron_config)
+
+    def forward(self, *args, **kwargs):
+        return self._model(*args, **kwargs)
+
+    @classmethod
+    def from_configs(
+        cls,
+        hf_config: PretrainedConfig,
+        neuron_config: NeuronConfig | None = None,
+        *,
+        text_neuron_config: NeuronConfig | None = None,
+        vision_neuron_config: object | None = None,
+    ) -> nn.Module:
+        """Create the model from configs, returning the implementation directly.
+
+        Accepts the multimodal call signature (``text_neuron_config=`` plus
+        ``vision_neuron_config=``) as well as the positional text-only one, and
+        ignores the vision half. That is not defensive padding -- it is forced by
+        this checkpoint:
+
+        ``configuration_mimo_v2.py`` sets ``self.vision_config`` unconditionally,
+        so ``hasattr(hf_config, "vision_config")`` is True even when the key is
+        absent from ``config.json``. That hasattr is what makes
+        ``NeuronPlatform.check_and_update_config`` synthesize a
+        ``vision_neuron_config``, which in turn makes ``load_model`` take the
+        multimodal ``from_configs`` branch. The offline example can dodge it with
+        a callable ``hf_overrides`` that ``delattr``s the attribute, but ``vllm
+        serve`` only accepts a JSON dict -- and a None-valued key still satisfies
+        hasattr, so there is no CLI-side spelling that works. Absorbing the
+        kwargs here is the one fix both entrypoints share.
+
+        Ignoring ``vision_neuron_config`` is sound because this port implements
+        the TEXT decoder only: the vision/audio towers are never built and their
+        checkpoint tensors are never referenced. Serve with
+        ``--limit-mm-per-prompt '{"image":0,"video":0,"audio":0}'`` so no request
+        can carry multimodal input the model cannot consume.
+        """
+        return cls._select_implementation(
+            hf_config, neuron_config if neuron_config is not None else text_neuron_config
+        )
+
+    @classmethod
+    def _select_implementation(
+        cls, hf_config: PretrainedConfig, neuron_config: NeuronConfig | None
+    ) -> nn.Module:
+        cls._validate_config(hf_config, neuron_config)
+
+        from .model import MiMoV2ForCausalLM as Model
+
+        return Model.from_configs(hf_config, neuron_config)
+
+    @classmethod
+    def _validate_config(
+        cls, hf_config: PretrainedConfig, neuron_config: NeuronConfig | None
+    ) -> None:
+        quantization = neuron_config.quantization if neuron_config else None
+        if quantization not in (None, "bf16", "fp8"):
+            raise ValueError(
+                f"MiMo-V2.5 supports quantization=None/'bf16'/'fp8' (the FP8 "
+                f"checkpoint is dequantized to BF16 at load time), got "
+                f"{quantization!r}."
+            )
+
+        # Platform detection raises on a non-Neuron host unless
+        # NEURON_PLATFORM_TARGET_OVERRIDE is set; treat that as "unknown" rather
+        # than an error so config-only construction still works off-instance.
+        try:
+            platform = get_platform_target()
+        except Exception:
+            platform = None
+        if platform in ("trn1", "trn1n", "inf2"):
+            raise ValueError(
+                f"MiMo-V2.5 needs 24 GB+ per device for its 256 BF16 experts; "
+                f"{platform} has 16 GB. Use trn2 or trn3."
+            )
+
+        # Attention is eager because the 192-wide Q/K heads exceed every fused
+        # attention kernel's 128 cap — a perf note, not a correctness issue.
+        # What IS a correctness trap is a malformed hybrid pattern: a wrong
+        # length would silently turn SWA layers into full-attention ones.
+        pattern = getattr(hf_config, "hybrid_layer_pattern", None)
+        num_layers = getattr(hf_config, "num_hidden_layers", None)
+        if pattern is not None and num_layers is not None and len(pattern) != num_layers:
+            raise ValueError(
+                f"hybrid_layer_pattern has {len(pattern)} entries but "
+                f"num_hidden_layers={num_layers}."
+            )

--- a/vllm_neuron/model/mimo_v2_5/model.py
+++ b/vllm_neuron/model/mimo_v2_5/model.py
@@ -545,8 +545,21 @@ class MiMoV2Attention(nn.Module):
         ``k``/``v`` are head-major ``[nkh, T, dim]``. V is zero-padded from
         ``v_head_dim`` to ``kv_cache_head_dim`` because both caches share one
         ``head_size``; the padding is sliced off again after every gather.
+
+        Delegates to ``NF.write_paged_kv_cache``, whose NKI kernel scatters the
+        rows straight into the cache buffer. A plain ``index_put_`` here cost
+        ~171 ms of the 199 ms decode step: XLA has no in-place scatter, so each
+        of the 96 writes per step materialized a copy of the whole 322 MB pool,
+        and because vLLM shares one raw cache tensor across ~6 layers the FX
+        aliasing pass could only make the last write per buffer in-place.
+
+        The kernel's aliased outputs are deliberately discarded (as llama3 does
+        with ``NF.qkv_proj``'s): rebinding ``self.k_cache`` mid-forward would
+        mutate module state under ``torch.compile``, and it isn't needed --
+        ``AliasingOutputRewritePass`` finds the kernel's getitem outputs in the
+        FX graph and rewires every downstream reader of the shared placeholder
+        to the latest write itself.
         """
-        nkh = self.num_key_value_heads_per_rank
         pad = self.kv_cache_head_dim - self.v_head_dim
 
         k_flat = k.reshape(-1, self.head_dim).to(self.k_cache.dtype)
@@ -555,16 +568,15 @@ class MiMoV2Attention(nn.Module):
             v_flat = F.pad(v_flat, (0, pad))
         v_flat = v_flat.to(self.v_cache.dtype)
 
-        block_indices = slot_mapping // block_size
-        position_indices = slot_mapping % block_size
-        head_indices = torch.arange(
-            nkh, dtype=torch.long, device=k.device
-        ).repeat_interleave(slot_mapping.shape[0])
-        block_indices = block_indices.repeat(nkh)
-        position_indices = position_indices.repeat(nkh)
-
-        self.k_cache.index_put_((block_indices, head_indices, position_indices), k_flat)
-        self.v_cache.index_put_((block_indices, head_indices, position_indices), v_flat)
+        NF.write_paged_kv_cache(
+            k_cache=self.k_cache,
+            v_cache=self.v_cache,
+            k=k_flat,
+            v=v_flat,
+            slot_mapping=slot_mapping,
+            block_size=block_size,
+            num_kv_heads=self.num_key_value_heads_per_rank,
+        )
 
     def _gather_paged_kv(
         self, block_table: torch.Tensor, block_size: int

--- a/vllm_neuron/model/mimo_v2_5/model.py
+++ b/vllm_neuron/model/mimo_v2_5/model.py
@@ -1,0 +1,1883 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+MiMo-V2.5 BF16 Implementation
+=============================
+
+Text decoder for ``MiMoV2ForCausalLM`` (``model_type="mimo_v2"``) on the
+PyTorch-native Neuron backend. Ported from the reference GPT-OSS
+(``gpt_oss/model_bf16.py``, parallelism patterns) and Qwen3.5-MoE
+(``qwen3_5_moe/model.py``, eager paged attention + static-block MoE) models.
+
+Architecture (48 layers, hidden 4096, 256 experts, top-8):
+
+  * **Hybrid attention.** ``hybrid_layer_pattern[i] == 0`` -> FULL attention,
+    ``== 1`` -> SWA (window 128). Note the polarity; the 9 full layers are
+    0, 5, 11, 17, 23, 29, 35, 41, 47.
+  * **Asymmetric head dims.** Q/K are 192 wide, V is 128. Both the paged K and
+    V caches are allocated at 192 (the framework derives one ``head_size`` per
+    layer) and V is zero-padded on write / sliced back on read.
+  * **Asymmetric KV heads.** Full layers have 4 KV heads, SWA layers 8.
+  * **Partial RoPE.** Only the first ``int(192 * 0.334) = 64`` dims are rotated.
+  * **Dual RoPE base.** ``rope_theta=1e7`` on full layers, ``swa_rope_theta=1e4``
+    on SWA layers, so the backbone maintains TWO cos/sin caches (mirroring HF's
+    ``rotary_emb`` / ``swa_rotary_emb``).
+  * **Attention sink.** One learned logit bias per Q head, on SWA layers only
+    (``add_swa_attention_sink_bias=True``, ``add_full_attention_sink_bias=False``).
+  * **``attention_value_scale=0.707``** multiplies V before it enters the cache.
+  * **Sigmoid ``noaux_tc`` router** with an ``e_score_correction_bias`` that
+    biases SELECTION but not the returned weights.
+  * **Layer 0 is dense** (``moe_layer_freq[0] == 0``); layers 1..47 are MoE.
+
+Why attention is hand-written eager instead of using the fused kernels:
+
+  * ``NF.flash_attention`` / ``NF.attention_decode`` / ``NF.segmented_attention``
+    all cap ``head_dim`` at 128. Worse, the flash gate inspects only V's shape
+    (128 here) so it would silently ACCEPT this model and then run with a
+    truncated Q/K. Prefill and decode therefore both use explicit fp32 eager
+    attention, which also lets us reproduce HF's sink handling exactly
+    (concat sink column -> subtract row max -> fp32 softmax -> drop the column).
+  * ``NF.qkv_proj`` and ``NF.o_proj`` ARE used: at TP=64 the fused QKV width is
+    512 (<= 4096 and <= H), ``H % 128 == 0``, and o_proj sees N=1 head of D=128.
+
+Supported parallelism: TP + SP + EP. Attention/MLP/embedding/LM-head DP are
+NOT supported (this model's KV geometry and torch router were not validated
+against the DP transitions); ``from_configs`` rejects those configs.
+"""
+
+import logging
+import math
+import os
+
+import nki.language as nl
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.distributed.parallel_state import get_tp_group
+
+import vllm_neuron.functional as NF
+import vllm_neuron.nn as neuron_nn
+from nkilib.core.moe.moe_cte.moe_cte import MoECTEImplementation
+from nkilib.core.utils.common_types import ActFnType, ExpertAffinityScaleMode
+from vllm_neuron.model.kv_cache import KVSpec, LayerSpec
+from vllm_neuron.model.neuron_config import NeuronConfig
+from vllm_neuron.functional.topk import topk as neuron_topk
+from vllm_neuron.nki.nki_hop import can_run_kernel
+from vllm_neuron.nn.embedding import VocabDimShardedEmbedding
+from vllm_neuron.nn.sampler import Sampler
+from vllm_neuron.utils.checkpoints import SafetensorsCheckpoint
+from vllm_neuron.utils.weight_loader import (
+    SafetensorsWeightLoader,
+    expert_parallel_interleaved_loader,
+    set_weight_loader,
+    sharding_weight_loader,
+)
+
+from .config import MiMoV2Config
+from .weight_loaders_bf16 import (
+    dense_down_fp8_loader,
+    dense_gate_up_fp8_loader,
+    expert_down_fp8_loader,
+    expert_gate_up_fp8_loader,
+    fused_qkv_fp8_loader,
+    infer_qkv_disk_tp,
+)
+
+logger = logging.getLogger(__name__)
+
+# Additive mask value for disallowed attention slots. Applied to fp32 scores
+# before the softmax; -1e9 (rather than finfo.min) keeps the subsequent
+# subtract-max finite even for an all-masked row.
+_MASK_NEG = -1e9
+
+
+def _topk_last_dim(tensor: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Top-k over the last dim, avoiding a bare ``torch.topk`` on device.
+
+    ``torch.topk`` lowers to an HLO ``sort``, which neuronx-cc rejects outright on
+    trn2 -- "[NCC_EVRF029] Operation sort is not supported on trn2. Use supported
+    equivalent operation like TopK or replace it with an alternate implementation
+    via Neuron Kernel Interface (NKI)." So the router's expert selection cannot
+    use it: it breaks COMPILATION (47 sorts, one per MoE layer), not just speed.
+
+    ``vllm_neuron.functional.topk.topk`` is that NKI alternative: with
+    ``process_group=None`` it takes the single-device path, using the rotational
+    NKI kernel where its feasibility gate admits the shape and falling back to
+    ``torch.topk`` otherwise -- which keeps CPU parity tests working unchanged.
+    The router's ``[T, E]`` score tensor is replicated, not sharded, so no
+    process group / rank is involved and ``gather_dim`` is inert.
+
+    Returns sorted-descending values with int64 indices, the same contract as
+    ``torch.topk``; the router's callers do not depend on the order either way.
+    """
+    return neuron_topk(tensor, k=k, dim=-1, gather_dim=-1)
+
+
+# =============================================================================
+# Section 0: Neuron-safe tensor helpers
+# =============================================================================
+
+
+def _repeat_interleave_heads(x: torch.Tensor, repeats: int, dim: int) -> torch.Tensor:
+    """Index-free equivalent of ``x.repeat_interleave(repeats, dim=dim)``.
+
+    ``torch.repeat_interleave`` lowers to an indirect (vector-DGE) gather on
+    Neuron: the per-output index ``arange(out) // repeats`` is a runtime access
+    pattern, so neuronx-cc cannot prove it in bounds and emits the DGE in
+    ``OOBMode.ERROR``, which faults at execute (nrta-1006). The broadcast form
+    below uses only ``unsqueeze``/``expand``/``reshape`` — no indirect
+    addressing — and is bit-identical: each slice along ``dim`` is repeated
+    ``repeats`` times CONSECUTIVELY, exactly ``repeat_interleave``'s order.
+    """
+    if repeats == 1:
+        return x
+    shape = list(x.shape)
+    exp = shape[: dim + 1] + [repeats] + shape[dim + 1 :]
+    out = shape[:dim] + [shape[dim] * repeats] + shape[dim + 1 :]
+    return x.unsqueeze(dim + 1).expand(*exp).reshape(*out)
+
+
+# =============================================================================
+# Section 1: RMS Normalization
+# =============================================================================
+
+
+class MiMoV2RMSNorm(nn.Module):
+    """Plain RMSNorm: ``weight * (x * rsqrt(mean(x^2) + eps))``.
+
+    Matches ``MiMoV2RMSNorm`` in the HF modeling file exactly: fp32 variance,
+    then multiply by the raw weight — there is NO ``1 + weight`` fold (unlike
+    Qwen3.5), so the checkpoint gamma is used as stored.
+    """
+
+    def __init__(self, hidden_size: int, eps: float, dtype: torch.dtype):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+# =============================================================================
+# Section 2: Rotary Position Embedding (partial RoPE, dual base)
+# =============================================================================
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rope_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Partial RoPE: rotate the first ``rope_dim`` dims, pass the rest through.
+
+    ``cos``/``sin`` arrive HALF-width (``[T, rope_dim // 2]``) and are doubled
+    here. HF emits them full-width and does not double inside its helper; the
+    two conventions are numerically identical as long as one is used
+    consistently, and this one is the device-proven form.
+
+    Args:
+        q: ``[num_q_heads, T, head_dim]``.
+        k: ``[num_kv_heads, T, head_dim]``.
+        cos, sin: ``[T, rope_dim // 2]``.
+        rope_dim: rotated width (64 for the released config).
+    """
+    cos = torch.cat((cos, cos), dim=-1).unsqueeze(0)  # [1, T, rope_dim]
+    sin = torch.cat((sin, sin), dim=-1).unsqueeze(0)
+
+    q_rot, q_pass = q[..., :rope_dim], q[..., rope_dim:]
+    k_rot, k_pass = k[..., :rope_dim], k[..., rope_dim:]
+
+    q_rot = (q_rot * cos) + (rotate_half(q_rot) * sin)
+    k_rot = (k_rot * cos) + (rotate_half(k_rot) * sin)
+
+    return torch.cat((q_rot, q_pass), dim=-1), torch.cat((k_rot, k_pass), dim=-1)
+
+
+class MiMoV2RotaryEmbedding(nn.Module):
+    """Partial RoPE frequency table. Two instances exist per model.
+
+    HF's ``MiMoV2RotaryEmbedding(config, is_swa)`` swaps in ``swa_rope_theta``
+    and ``swa_head_dim`` when ``is_swa``, then computes
+    ``dim = int(head_dim * partial_rotary_factor)`` and
+    ``inv_freq = 1 / base ** (arange(0, dim, 2) / dim)``. The released config
+    has ``head_dim == swa_head_dim == 192`` so only the base differs
+    (1e7 full vs 1e4 SWA) — but the geometry is read per-variant anyway so a
+    future config with differing SWA head dims still works.
+    """
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: MiMoV2Config, is_swa: bool):
+        super().__init__()
+        base = config.swa_rope_theta if is_swa else config.rope_theta
+        head_dim = config.swa_head_dim if is_swa else config.head_dim
+        dim = int(head_dim * config.partial_rotary_factor)
+        if dim % 2 != 0:
+            raise ValueError(
+                f"rope_dim must be even, got {dim} "
+                f"(head_dim={head_dim}, partial_rotary_factor="
+                f"{config.partial_rotary_factor})"
+            )
+        self.rope_dim = dim
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.float, device="cpu") / dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        device: torch.device = None,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns ``(cos, sin)``, each ``[T, rope_dim // 2]``."""
+        inv_freq = self.inv_freq.to(device=device, dtype=torch.float32)
+        freqs = torch.outer(position_ids.float(), inv_freq)  # [T, rope_dim/2]
+        return freqs.cos().to(dtype), freqs.sin().to(dtype)
+
+
+# =============================================================================
+# Section 3: Attention (hybrid full / sliding-window)
+# =============================================================================
+
+
+class MiMoV2Attention(nn.Module):
+    """Hybrid attention with TP head sharding and an eager paged KV path.
+
+    Per-layer geometry is selected from ``hybrid_layer_pattern``: full layers
+    use ``num_key_value_heads`` and no window, SWA layers use
+    ``swa_num_key_value_heads`` plus a ``sliding_window``-wide window and the
+    learned per-head sink bias.
+
+    KV cache layout: ``[num_blocks, kv_heads_per_rank, block_size, 192]`` for
+    BOTH K and V. V is only 128 wide, so the trailing 64 columns are written as
+    zeros and sliced off after every gather. The framework derives a single
+    ``head_size`` per layer from :class:`LayerSpec`, so a 128-wide V cache would
+    require a second spec field that does not exist.
+    """
+
+    def __init__(self, config: MiMoV2Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.dtype = config.torch_dtype
+        self.hidden_size = config.hidden_size
+        self.is_swa = config.is_swa_layer(layer_idx)
+
+        # <-- MODEL-SPECIFIC: per-layer full/SWA geometry
+        if self.is_swa:
+            self.num_attention_heads = config.swa_num_attention_heads
+            self.num_key_value_heads = config.swa_num_key_value_heads
+            self.head_dim = config.swa_head_dim
+            self.v_head_dim = config.swa_v_head_dim
+            self.sliding_window = config.sliding_window
+            has_sink = config.add_swa_attention_sink_bias
+        else:
+            self.num_attention_heads = config.num_attention_heads
+            self.num_key_value_heads = config.num_key_value_heads
+            self.head_dim = config.head_dim
+            self.v_head_dim = config.v_head_dim
+            self.sliding_window = None
+            has_sink = config.add_full_attention_sink_bias
+
+        # HF: ``self.scaling = self.head_dim ** -0.5`` — the Q/K width (192),
+        # NOT the V width. Using v_head_dim here would silently mis-scale every
+        # logit by sqrt(192/128).
+        self.scaling = self.head_dim**-0.5
+        self.rope_dim = int(self.head_dim * config.partial_rotary_factor)
+        self.v_scale = config.attention_value_scale
+
+        # Single cache head width for both K and V (see class docstring).
+        self.kv_cache_head_dim = max(self.head_dim, self.v_head_dim)
+
+        # >>> PARALLELISM: TP head sharding <<<
+        self.tp_group = get_tp_group()
+        self.world_size = self.tp_group.world_size
+        self.rank = self.tp_group.rank_in_group
+
+        if self.num_attention_heads % self.world_size != 0:
+            raise ValueError(
+                f"num_attention_heads ({self.num_attention_heads}) must be "
+                f"divisible by tp_degree ({self.world_size})"
+            )
+        self.num_attention_heads_per_rank = self.num_attention_heads // self.world_size
+
+        # KV replication: when TP >= kv_heads every rank keeps ONE replicated KV
+        # head (consecutive groups of num_kv_replicas ranks share it) instead of
+        # a zero-width slice from an integer division.
+        if self.world_size >= self.num_key_value_heads:
+            self.num_key_value_heads_per_rank = 1
+            self.num_kv_replicas = self.world_size // self.num_key_value_heads
+        else:
+            self.num_key_value_heads_per_rank = (
+                self.num_key_value_heads // self.world_size
+            )
+            self.num_kv_replicas = 1
+        self.num_key_value_groups = (
+            self.num_attention_heads_per_rank // self.num_key_value_heads_per_rank
+        )
+
+        # >>> PARALLELISM: fused QKV / O shapes for this rank <<<
+        q_size = self.num_attention_heads_per_rank * self.head_dim
+        k_size = self.num_key_value_heads_per_rank * self.head_dim
+        v_size = self.num_key_value_heads_per_rank * self.v_head_dim
+        self.q_size, self.k_size, self.v_size = q_size, k_size, v_size
+        self.qkv_split_indices = [q_size, q_size + k_size]
+
+        self.qkv_proj_weight = nn.Parameter(
+            torch.empty(self.hidden_size, q_size + k_size + v_size, dtype=self.dtype)
+        )
+        self.o_proj_weight = nn.Parameter(
+            torch.empty(
+                self.num_attention_heads_per_rank * self.v_head_dim,
+                self.hidden_size,
+                dtype=self.dtype,
+            )
+        )
+
+        # <-- MODEL-SPECIFIC: learned attention sink, one scalar per Q head.
+        # nn.Parameter (not a buffer) because ``load_sharded_pipelined``
+        # iterates ``named_parameters`` only — a buffer would never be loaded.
+        self.attention_sink_bias = (
+            nn.Parameter(
+                torch.zeros(self.num_attention_heads_per_rank, dtype=torch.float32)
+            )
+            if has_sink
+            else None
+        )
+
+        # Bound externally via bind_kv_cache().
+        self.k_cache: torch.Tensor | None = None
+        self.v_cache: torch.Tensor | None = None
+
+        self.qkv_disk_tp = config.qkv_disk_tp
+        self._setup_weight_loaders()
+
+    def set_qkv_disk_tp(self, disk_tp: int) -> None:
+        """Pin the fused-QKV on-disk shard count and reinstall its loader.
+
+        Called from ``load_weights`` once the checkpoint has been probed; see
+        :meth:`MiMoV2ForCausalLM._resolve_qkv_disk_tp` for why it cannot be
+        known at construction time.
+        """
+        self.qkv_disk_tp = disk_tp
+        self._install_qkv_loader()
+
+    def _install_qkv_loader(self):
+        set_weight_loader(
+            self.qkv_proj_weight,
+            fused_qkv_fp8_loader(
+                num_attention_heads=self.num_attention_heads,
+                num_key_value_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                v_head_dim=self.v_head_dim,
+                num_shards=self.world_size,
+                num_kv_replicas=self.num_kv_replicas,
+                dtype=self.dtype,
+                disk_tp=self.qkv_disk_tp,
+            ),
+        )
+
+    def _setup_weight_loaders(self):
+        """Attach TP-sharding + FP8-dequantizing loaders to each parameter."""
+        self._install_qkv_loader()
+        # o_proj is in ``quantization_config.ignored_layers`` — stored as plain
+        # bf16 ``[hidden, num_heads * v_head_dim]``, so the generic sharding
+        # loader serves it (transposed storage, shard the input dim).
+        set_weight_loader(
+            self.o_proj_weight,
+            sharding_weight_loader(
+                shard_dim=0,
+                shard_size=(self.num_attention_heads * self.v_head_dim)
+                // self.world_size,
+                num_shards=self.world_size,
+                is_storage_transposed=True,
+            ),
+        )
+        if self.attention_sink_bias is not None:
+            set_weight_loader(
+                self.attention_sink_bias,
+                sharding_weight_loader(
+                    shard_dim=0,
+                    shard_size=self.num_attention_heads_per_rank,
+                    num_shards=self.world_size,
+                ),
+            )
+
+    # ── Forward dispatch ─────────────────────────────────────────────────
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: dict,
+    ) -> torch.Tensor:
+        layer_name = f"layers.{self.layer_idx}.self_attn"
+        max_query_len = attn_metadata[layer_name]["max_query_len"]
+        decode_token_threshold = attn_metadata[layer_name]["decode_token_threshold"]
+
+        if max_query_len <= decode_token_threshold:
+            return self.forward_decode(
+                hidden_states, positions, position_embeddings, attn_metadata
+            )
+
+        # >>> PARALLELISM: all-gather out of SP before attention <<<
+        if self.world_size > 1:
+            hidden_states = self.tp_group.all_gather(hidden_states, dim=0)
+        return self.forward_prefill(
+            hidden_states, positions, position_embeddings, attn_metadata
+        )
+
+    # ── Shared QKV projection ────────────────────────────────────────────
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project, split, scale V, and apply partial RoPE.
+
+        Returns ``(q, k, v)`` as ``[heads, T, dim]`` head-major tensors, with
+        RoPE already applied to Q/K and ``attention_value_scale`` already
+        folded into V (HF applies it FIRST in ``_forward_attention``, before
+        the rope split, so the cached V is the scaled one).
+        """
+        tokens = hidden_states.shape[0]
+        nqh = self.num_attention_heads_per_rank
+        nkh = self.num_key_value_heads_per_rank
+
+        qkv = NF.qkv_proj(
+            hidden=hidden_states.unsqueeze(0),
+            qkv_weights=self.qkv_proj_weight,
+            bias=None,
+        ).squeeze(0)
+        q, k, v = torch.tensor_split(qkv, self.qkv_split_indices, dim=-1)
+
+        q = q.view(tokens, nqh, self.head_dim).transpose(0, 1)
+        k = k.view(tokens, nkh, self.head_dim).transpose(0, 1)
+        v = v.view(tokens, nkh, self.v_head_dim).transpose(0, 1)
+
+        # <-- MODEL-SPECIFIC: attention_value_scale, applied before caching.
+        if self.v_scale is not None:
+            v = v * self.v_scale
+
+        cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb(q, k, cos, sin, self.rope_dim)
+        return q, k, v
+
+    # ── Eager attention core ─────────────────────────────────────────────
+
+    def _eager_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        additive_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """fp32 eager attention with HF's exact sink handling.
+
+        Mirrors ``eager_attention_forward`` in the HF modeling file: scaled
+        scores, additive mask, concat the per-head sink as one extra logit
+        column, subtract the row max, fp32 softmax, then DROP the sink column
+        before the value matmul. The sink therefore removes probability mass
+        from the real slots without contributing any value vector.
+
+        Args:
+            q: ``[B, nqh, S_q, head_dim]``.
+            k: ``[B, nqh, S_kv, head_dim]`` (already GQA-expanded).
+            v: ``[B, nqh, S_kv, v_head_dim]`` (already GQA-expanded).
+            additive_mask: broadcastable to ``[B, nqh, S_q, S_kv]``; 0 where
+                allowed, ``_MASK_NEG`` where masked.
+
+        Returns:
+            ``[B, nqh, S_q, v_head_dim]`` in the module dtype.
+        """
+        scores = torch.matmul(q.float(), k.float().transpose(-2, -1)) * self.scaling
+        scores = scores + additive_mask
+
+        if self.attention_sink_bias is not None:
+            B, nqh, S_q, _ = scores.shape
+            sink = self.attention_sink_bias.float().reshape(1, nqh, 1, 1).expand(
+                B, nqh, S_q, 1
+            )
+            scores = torch.cat([scores, sink], dim=-1)
+
+        scores = scores - scores.max(dim=-1, keepdim=True).values
+        probs = torch.softmax(scores, dim=-1)
+        if self.attention_sink_bias is not None:
+            probs = probs[..., :-1]
+
+        return torch.matmul(probs, v.float()).to(self.dtype)
+
+    def _out_proj(self, attn_out: torch.Tensor, tokens: int) -> torch.Tensor:
+        """``[B, nqh, S, v_head_dim]`` -> ``[T, hidden]`` via ``NF.o_proj``.
+
+        The 4-D ``[B, N, D, S]`` layout is used (rather than the 3-D one) so the
+        NKI output-projection kernel is eligible: it needs ``D <= 128`` (V is
+        exactly 128), ``N <= 17`` (1 head per rank at TP=64), and ``H % 2 == 0``.
+        """
+        B, nqh, S, vhd = attn_out.shape
+        active = attn_out.permute(0, 1, 3, 2).contiguous()  # [B, N, D, S]
+        out = NF.o_proj(active, self.o_proj_weight, None)  # [B, S, H]
+        return out.reshape(tokens, self.hidden_size)
+
+    # ── Paged KV cache write ─────────────────────────────────────────────
+
+    def _write_paged_kv_cache(
+        self, k: torch.Tensor, v: torch.Tensor, slot_mapping: torch.Tensor, block_size: int
+    ) -> None:
+        """Scatter post-RoPE K and (padded) V into the paged cache.
+
+        ``k``/``v`` are head-major ``[nkh, T, dim]``. V is zero-padded from
+        ``v_head_dim`` to ``kv_cache_head_dim`` because both caches share one
+        ``head_size``; the padding is sliced off again after every gather.
+        """
+        nkh = self.num_key_value_heads_per_rank
+        pad = self.kv_cache_head_dim - self.v_head_dim
+
+        k_flat = k.reshape(-1, self.head_dim).to(self.k_cache.dtype)
+        v_flat = v.reshape(-1, self.v_head_dim)
+        if pad:
+            v_flat = F.pad(v_flat, (0, pad))
+        v_flat = v_flat.to(self.v_cache.dtype)
+
+        block_indices = slot_mapping // block_size
+        position_indices = slot_mapping % block_size
+        head_indices = torch.arange(
+            nkh, dtype=torch.long, device=k.device
+        ).repeat_interleave(slot_mapping.shape[0])
+        block_indices = block_indices.repeat(nkh)
+        position_indices = position_indices.repeat(nkh)
+
+        self.k_cache.index_put_((block_indices, head_indices, position_indices), k_flat)
+        self.v_cache.index_put_((block_indices, head_indices, position_indices), v_flat)
+
+    def _gather_paged_kv(
+        self, block_table: torch.Tensor, block_size: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Gather the paged window into ``[B, nkh, S_ctx, dim]`` K and V.
+
+        FP8 caches are dequantized to the compute dtype BEFORE the fancy index:
+        indexing into a float8 tensor is not supported and gathers garbage on
+        device. V is sliced back to ``v_head_dim`` here.
+        """
+        B, num_blocks_per_seq = block_table.shape
+        S_ctx = num_blocks_per_seq * block_size
+        nkh = self.num_key_value_heads_per_rank
+
+        if self.k_cache.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            k_src = self.k_cache.to(self.dtype)
+            v_src = self.v_cache.to(self.dtype)
+        else:
+            k_src, v_src = self.k_cache, self.v_cache
+
+        flat_idx = block_table.reshape(-1)
+        k_blocks = k_src[flat_idx].view(
+            B, num_blocks_per_seq, nkh, block_size, self.kv_cache_head_dim
+        )
+        v_blocks = v_src[flat_idx].view(
+            B, num_blocks_per_seq, nkh, block_size, self.kv_cache_head_dim
+        )
+        # .contiguous() guards the device's non-contiguous-reshape hazard.
+        k_gathered = k_blocks.permute(0, 2, 1, 3, 4).reshape(
+            B, nkh, S_ctx, self.kv_cache_head_dim
+        )
+        v_gathered = v_blocks.permute(0, 2, 1, 3, 4).reshape(
+            B, nkh, S_ctx, self.kv_cache_head_dim
+        )
+        return k_gathered[..., : self.head_dim], v_gathered[..., : self.v_head_dim]
+
+    # ── Prefill ──────────────────────────────────────────────────────────
+
+    def forward_prefill(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: dict,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.to(self.dtype)
+        tokens = hidden_states.shape[0]
+        layer_name = f"layers.{self.layer_idx}.self_attn"
+        meta = attn_metadata[layer_name]
+
+        if meta.get("kv_segment_size"):
+            # Chunked prefill / prefix caching would need the prior paged
+            # window spliced with the live K/V (as the decode path does).
+            # Not implemented: single-shot prefill is what the default
+            # NeuronConfig produces (kv_segment_size_buckets is None -> 0).
+            raise NotImplementedError(
+                "MiMo-V2.5 does not support chunked prefill / prefix caching "
+                "yet (kv_segment_size must be 0)."
+            )
+
+        q, k, v = self._project_qkv(hidden_states, position_embeddings)
+
+        self._write_paged_kv_cache(k, v, meta["slot_mapping"], meta["block_size"])
+
+        # Prefill runs one sequence at a time on Neuron.
+        nqh = self.num_attention_heads_per_rank
+        q = q.unsqueeze(0)  # [1, nqh, T, head_dim]
+        k = _repeat_interleave_heads(
+            k.unsqueeze(0), self.num_key_value_groups, dim=1
+        )
+        v = _repeat_interleave_heads(
+            v.unsqueeze(0), self.num_key_value_groups, dim=1
+        )
+
+        mask = self._prefill_mask(tokens, hidden_states.device)
+        attn_out = self._eager_attention(q, k, v, mask)
+
+        attn_out = self._out_proj(attn_out, tokens)
+
+        # >>> PARALLELISM: reduce-scatter back to SP <<<
+        if self.world_size > 1:
+            attn_out = self.tp_group.reduce_scatter(attn_out, dim=0)
+        return attn_out.contiguous()
+
+    def _prefill_mask(self, tokens: int, device: torch.device) -> torch.Tensor:
+        """Additive causal (+ sliding-window) mask, ``[1, 1, T, T]``.
+
+        Built from sequence-order indices rather than ``positions``: in a
+        single-shot prefill the two agree for every real token, and the runner's
+        right-padding repeats the last real position (which would make padded
+        rows alias the last real row under a position-based mask). Padded rows'
+        outputs are discarded downstream either way.
+        """
+        idx = torch.arange(tokens, device=device)
+        allowed = idx.view(1, tokens) <= idx.view(tokens, 1)
+        if self.sliding_window is not None:
+            allowed = allowed & (
+                idx.view(1, tokens) > idx.view(tokens, 1) - self.sliding_window
+            )
+        return torch.where(
+            allowed,
+            torch.zeros((), dtype=torch.float32, device=device),
+            torch.full((), _MASK_NEG, dtype=torch.float32, device=device),
+        ).view(1, 1, tokens, tokens)
+
+    # ── Decode ───────────────────────────────────────────────────────────
+
+    def forward_decode(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: dict,
+    ) -> torch.Tensor:
+        """Eager paged decode.
+
+        Ordering is load-bearing: the prior window is gathered, the live K/V is
+        spliced into that LOCAL copy, attention runs, and only THEN is the cache
+        written. An ``index_put_`` followed by an indexed gather of the same
+        tensor is not ordered under neuronx-cc/XLA, so a write-then-read would
+        read the stale slot at the current token's own position — correct on CPU
+        eager, corrupt on device.
+        """
+        layer_name = f"layers.{self.layer_idx}.self_attn"
+        meta = attn_metadata[layer_name]
+        block_table = meta["block_table_tensor"]
+        block_size = meta["block_size"]
+        slot_mapping = meta["slot_mapping"]
+
+        hidden_states = hidden_states.to(self.dtype)
+        tokens = hidden_states.shape[0]
+        B = block_table.shape[0]
+        S_decode = tokens // B
+        S_ctx = block_table.shape[1] * block_size
+        nqh = self.num_attention_heads_per_rank
+        nkh = self.num_key_value_heads_per_rank
+
+        q, k, v = self._project_qkv(hidden_states, position_embeddings)
+
+        k_gathered, v_gathered = self._gather_paged_kv(block_table, block_size)
+
+        # Position of each active token inside the GATHERED window. For SWA the
+        # runner trims the block table to the window-relevant blocks and reports
+        # the trim origin as ``swa_kv_pos_offset`` (= start_block * block_size),
+        # so both the splice index and the mask must live in that trimmed frame.
+        # Mixing frames degenerates the window test once the trim activates.
+        pos = positions.reshape(B, S_decode).long()
+        if self.sliding_window is not None:
+            offset = meta.get("swa_kv_pos_offset")
+            if offset is not None:
+                # clamp(min=0): a padding/freed row has its position zero-padded
+                # to 0 while the offset is positive, so the shift would go
+                # negative and mark the whole (all -1 block_table) window valid,
+                # reading stale K -> NaN. Clamping collapses that row's window
+                # to the self slot only.
+                pos = torch.clamp(pos - offset.reshape(B, 1).long(), min=0)
+        pos = torch.clamp(pos, max=S_ctx - 1)
+
+        # Splice the live post-RoPE K/V into the LOCAL gathered window.
+        k_live = k.reshape(nkh, B, S_decode, self.head_dim).permute(1, 0, 2, 3)
+        v_live = v.reshape(nkh, B, S_decode, self.v_head_dim).permute(1, 0, 2, 3)
+        k_idx = pos.view(B, 1, S_decode, 1).expand(B, nkh, S_decode, self.head_dim)
+        v_idx = pos.view(B, 1, S_decode, 1).expand(B, nkh, S_decode, self.v_head_dim)
+        k_gathered = k_gathered.scatter(2, k_idx, k_live.to(k_gathered.dtype))
+        v_gathered = v_gathered.scatter(2, v_idx, v_live.to(v_gathered.dtype))
+
+        k_gathered = _repeat_interleave_heads(
+            k_gathered, self.num_key_value_groups, dim=1
+        )
+        v_gathered = _repeat_interleave_heads(
+            v_gathered, self.num_key_value_groups, dim=1
+        )
+
+        q = q.reshape(nqh, B, S_decode, self.head_dim).permute(1, 0, 2, 3)
+        mask = self._decode_mask(pos, S_ctx, hidden_states.device)
+        attn_out = self._eager_attention(q, k_gathered, v_gathered, mask)
+
+        attn_out = self._out_proj(attn_out, tokens)
+
+        # Cache write AFTER attention (see method docstring). slot_mapping is in
+        # the FULL cache frame, unaffected by any SWA block-table trim.
+        self._write_paged_kv_cache(k, v, slot_mapping, block_size)
+
+        # >>> PARALLELISM: TP all-reduce (no SP during decode) <<<
+        if self.world_size > 1:
+            attn_out = self.tp_group.all_reduce(attn_out)
+        return attn_out
+
+    def _decode_mask(
+        self, pos: torch.Tensor, S_ctx: int, device: torch.device
+    ) -> torch.Tensor:
+        """Additive mask over the gathered window, ``[B, 1, S_decode, S_ctx]``.
+
+        ``pos`` is each active token's slot in the gathered (possibly trimmed)
+        frame; a query attends slots ``0..pos`` inclusive, further restricted to
+        the trailing ``sliding_window`` slots on SWA layers.
+        """
+        B, S_decode = pos.shape
+        slot = torch.arange(S_ctx, device=device).view(1, 1, 1, S_ctx)
+        end = pos.view(B, 1, S_decode, 1)
+        allowed = slot <= end
+        if self.sliding_window is not None:
+            start = torch.clamp(end - self.sliding_window + 1, min=0)
+            allowed = allowed & (slot >= start)
+        return torch.where(
+            allowed,
+            torch.zeros((), dtype=torch.float32, device=device),
+            torch.full((), _MASK_NEG, dtype=torch.float32, device=device),
+        )
+
+
+# =============================================================================
+# Section 4: Dense MLP (layer 0 only)
+# =============================================================================
+
+
+class MiMoV2DenseMLP(nn.Module):
+    """SwiGLU MLP for the layers where ``moe_layer_freq[i]`` is 0.
+
+    Only layer 0 in the released config. ``NF.mlp`` is used because it has a
+    PyTorch fallback (CPU compile mode works) and fuses gate/up/down.
+    """
+
+    def __init__(self, config: MiMoV2Config):
+        super().__init__()
+        self.dtype = config.torch_dtype
+        self.hidden_size = config.hidden_size
+
+        self.tp_group = get_tp_group()
+        self.world_size = self.tp_group.world_size
+        if config.intermediate_size % self.world_size != 0:
+            raise ValueError(
+                f"intermediate_size ({config.intermediate_size}) must be "
+                f"divisible by tp_degree ({self.world_size})"
+            )
+        self.intermediate_size_per_rank = config.intermediate_size // self.world_size
+
+        i_pr = self.intermediate_size_per_rank
+        self.gate_proj_weight = nn.Parameter(
+            torch.empty(self.hidden_size, i_pr, dtype=self.dtype)
+        )
+        self.up_proj_weight = nn.Parameter(
+            torch.empty(self.hidden_size, i_pr, dtype=self.dtype)
+        )
+        self.down_proj_weight = nn.Parameter(
+            torch.empty(i_pr, self.hidden_size, dtype=self.dtype)
+        )
+
+        self.quantized = config.is_fp8_checkpoint
+        self._install_loaders()
+
+    def set_quantized(self, quantized: bool) -> None:
+        """Switch between the fp8-dequantizing and plain-bf16 loaders."""
+        if quantized == self.quantized:
+            return
+        self.quantized = quantized
+        self._install_loaders()
+
+    def _install_loaders(self):
+        i_pr = self.intermediate_size_per_rank
+        quantized = self.quantized
+        set_weight_loader(
+            self.gate_proj_weight,
+            dense_gate_up_fp8_loader(i_pr, self.world_size, self.dtype)
+            if quantized
+            else _plain_transposed_shard_loader(i_pr, self.world_size, shard_rows=True),
+        )
+        set_weight_loader(
+            self.up_proj_weight,
+            dense_gate_up_fp8_loader(i_pr, self.world_size, self.dtype)
+            if quantized
+            else _plain_transposed_shard_loader(i_pr, self.world_size, shard_rows=True),
+        )
+        set_weight_loader(
+            self.down_proj_weight,
+            dense_down_fp8_loader(i_pr, self.world_size, self.dtype)
+            if quantized
+            else _plain_transposed_shard_loader(
+                i_pr, self.world_size, shard_rows=False
+            ),
+        )
+
+    def forward(
+        self, hidden_states: torch.Tensor, is_decode: bool
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.to(self.dtype)
+
+        # >>> PARALLELISM: all-gather out of SP before the column-parallel matmul
+        # <<< In prefill the residual stream is sequence-parallel (T/tp rows per
+        # rank), but a column-then-row-parallel MLP needs the FULL sequence: each
+        # rank computes a partial sum over its intermediate slice, and the
+        # reduce_scatter below both completes that sum and returns to the SP
+        # layout. Without the gather, reduce_scatter gets T/tp rows and asserts on
+        # ``shape[0] % world_size`` (T/tp**2 is not integral). Same shape contract
+        # as MiMoV2Attention.forward and MiMoV2SparseMoeBlock.forward_prefill.
+        if not is_decode and self.world_size > 1:
+            hidden_states = self.tp_group.all_gather(hidden_states, dim=0)
+
+        out = NF.mlp(
+            hidden=hidden_states,
+            gate_w=self.gate_proj_weight,
+            up_w=self.up_proj_weight,
+            down_w=self.down_proj_weight,
+            act_fn=ActFnType.SiLU,
+        )
+        if self.world_size > 1:
+            # Column-then-row parallel: every rank holds a partial sum over the
+            # intermediate dim. Decode all-reduces; prefill reduce-scatters
+            # straight back into the SP layout.
+            if is_decode:
+                out = self.tp_group.all_reduce(out)
+            else:
+                out = self.tp_group.reduce_scatter(out, dim=0)
+        return out.to(self.dtype)
+
+
+def _plain_transposed_shard_loader(
+    shard_size: int, num_shards: int, shard_rows: bool
+) -> SafetensorsWeightLoader:
+    """BF16 fallback loader for a dense MLP projection.
+
+    Used only for an unquantized re-export of the checkpoint (the released one
+    is fp8, handled by the dequantizing loaders). HF stores ``[out, in]``; our
+    params are ``[in, out]``. ``shard_rows`` selects gate/up (shard HF dim 0)
+    vs down (shard HF dim 1).
+    """
+    return sharding_weight_loader(
+        shard_dim=1 if shard_rows else 0,
+        shard_size=shard_size,
+        num_shards=num_shards,
+        is_storage_transposed=True,
+    )
+
+
+# =============================================================================
+# Section 5: Sparse MoE (sigmoid noaux_tc router + static-block NF kernels)
+# =============================================================================
+
+
+class MiMoV2SparseMoeBlock(nn.Module):
+    """256-expert top-8 MoE with EP, and a hand-written ``noaux_tc`` router.
+
+    The router CANNOT use ``NF.router`` or the fused ``moe_block_tkg`` router:
+    neither can express MiMo's group-limited selection
+    (``group_score = top2(scores_for_choice).sum()`` per group, keep
+    ``topk_group`` groups) nor the bias split — ``e_score_correction_bias`` is
+    added for SELECTION only, while the returned weights are gathered from the
+    UNBIASED sigmoid scores. So routing is computed in fp32 torch and only the
+    expert MLPs go through the NKI kernels
+    (``moe_cte`` for prefill, ``moe_tkg`` for decode).
+
+    With the released config (``n_group=1``, ``topk_group=1``) the group mask is
+    all ones and selection degenerates to a plain top-8 over the biased scores,
+    but the general form is implemented so a grouped config still works.
+    """
+
+    def __init__(self, config: MiMoV2Config):
+        super().__init__()
+        from vllm.config import get_current_vllm_config
+        from vllm_neuron.parallel.neuron_parallel_state import (
+            get_neuron_ep_degree,
+            get_neuron_ep_rank,
+            get_neuron_ep_tp_group,
+        )
+
+        self.dtype = config.torch_dtype
+        self.hidden_size = config.hidden_size
+        self.tp_group = get_tp_group()
+
+        self.ep_enabled = (
+            get_current_vllm_config().parallel_config.enable_expert_parallel
+        )
+        self.ep_degree = get_neuron_ep_degree() if self.ep_enabled else 1
+        self.ep_rank = get_neuron_ep_rank() if self.ep_enabled else 0
+        self.ep_tp_group = (
+            get_neuron_ep_tp_group() if self.ep_enabled else self.tp_group
+        )
+        # Intermediate-dim sharding degree within an EP partition (1 for pure EP).
+        self.tp_degree = self.tp_group.world_size // self.ep_degree
+        # Outer collective group: the full TP world in both TP-only and EP modes.
+        self.moe_group = self.tp_group
+
+        self.total_num_experts = config.n_routed_experts
+        if self.total_num_experts % self.ep_degree != 0:
+            raise ValueError(
+                f"n_routed_experts ({self.total_num_experts}) must be divisible "
+                f"by ep_degree ({self.ep_degree})"
+            )
+        self.num_local_experts = self.total_num_experts // self.ep_degree
+        self.top_k = config.num_experts_per_tok
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.norm_topk_prob = config.norm_topk_prob
+        self.routed_scaling_factor = (
+            config.routed_scaling_factor
+            if config.routed_scaling_factor is not None
+            else 1.0
+        )
+        if config.moe_intermediate_size % self.tp_degree != 0:
+            raise ValueError(
+                f"moe_intermediate_size ({config.moe_intermediate_size}) must "
+                f"be divisible by moe tp_degree ({self.tp_degree})"
+            )
+        self.intermediate_size_per_rank = (
+            config.moe_intermediate_size // self.tp_degree
+        )
+        # Baseline MoE dispatch block size for decode, where a single token
+        # produces the minimum block count regardless. Prefill derives its own
+        # value from the token count -- see ``_prefill_block_size``.
+        self.block_size = int(os.environ.get("VLLM_NEURON_MOE_BLOCK_SIZE", 256))
+
+        # Router weight + correction bias are fp32 and REPLICATED (never
+        # EP-sharded): every rank scores all experts, then keeps its own slice.
+        self.router_weight = nn.Parameter(
+            torch.empty(self.total_num_experts, self.hidden_size, dtype=torch.float32)
+        )
+        self.e_score_correction_bias = nn.Parameter(
+            torch.zeros(self.total_num_experts, dtype=torch.float32)
+        )
+
+        self.gate_up_proj_weight = nn.Parameter(
+            torch.empty(
+                self.num_local_experts,
+                self.hidden_size,
+                self.intermediate_size_per_rank * 2,
+                dtype=self.dtype,
+            )
+        )
+        self.down_proj_weight = nn.Parameter(
+            torch.empty(
+                self.num_local_experts,
+                self.intermediate_size_per_rank,
+                self.hidden_size,
+                dtype=self.dtype,
+            )
+        )
+
+        self.quantized = config.is_fp8_checkpoint
+        self._setup_weight_loaders()
+
+    def set_quantized(self, quantized: bool) -> None:
+        """Switch between the fp8-dequantizing and plain-bf16 expert loaders."""
+        if quantized == self.quantized:
+            return
+        self.quantized = quantized
+        self._setup_weight_loaders()
+
+    def _setup_weight_loaders(self):
+        quantized = self.quantized
+        local_expert_indices = list(
+            range(
+                self.ep_rank * self.num_local_experts,
+                (self.ep_rank + 1) * self.num_local_experts,
+            )
+        )
+
+        def _maybe_ep_wrap(loader):
+            # MiMo ships one key per expert, so the checkpoint mapping is a flat
+            # INTERLEAVED list ([e0_gate_w, e0_gate_s, e0_up_w, e0_up_s, ...])
+            # and the interleaved EP wrapper slices it to this rank's experts
+            # before the transform ever runs.
+            if self.ep_degree > 1:
+                return expert_parallel_interleaved_loader(
+                    local_expert_indices, loader, self.total_num_experts
+                )
+            return loader
+
+        set_weight_loader(
+            self.gate_up_proj_weight,
+            _maybe_ep_wrap(
+                expert_gate_up_fp8_loader(
+                    shard_size=self.intermediate_size_per_rank * 2,
+                    num_shards=self.tp_degree,
+                    quantized=quantized,
+                    dtype=self.dtype,
+                )
+            ),
+        )
+        set_weight_loader(
+            self.down_proj_weight,
+            _maybe_ep_wrap(
+                expert_down_fp8_loader(
+                    shard_size=self.intermediate_size_per_rank,
+                    num_shards=self.tp_degree,
+                    quantized=quantized,
+                    dtype=self.dtype,
+                )
+            ),
+        )
+
+    # ── Router (noaux_tc, fp32 torch) ────────────────────────────────────
+
+    def _route(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """MiMo's ``noaux_tc`` routing, verbatim from ``MiMoV2MoEGate``.
+
+        Returns ``(expert_affinities, expert_index)`` where affinities is a
+        dense ``[T, E]`` fp32 tensor holding the top-k weights scattered into
+        their expert slots (zeros elsewhere), and ``expert_index`` is
+        ``[T, top_k]`` int32 global expert ids.
+        """
+        x = hidden_states.float()
+        logits = F.linear(x, self.router_weight)  # [T, E]
+        scores = logits.sigmoid()
+
+        # The bias steers SELECTION only; the returned weight is the UNBIASED
+        # score. Folding the bias into the weight is a silent accuracy bug.
+        scores_for_choice = scores + self.e_score_correction_bias.unsqueeze(0)
+
+        if self.n_group > 1:
+            T = scores.shape[0]
+            group_scores = (
+                _topk_last_dim(scores_for_choice.view(T, self.n_group, -1), 2)[0]
+                .sum(dim=-1)
+            )  # [T, n_group]
+            group_idx = _topk_last_dim(group_scores, self.topk_group)[1]
+            group_mask = torch.zeros_like(group_scores).scatter_(1, group_idx, 1.0)
+            score_mask = (
+                group_mask.unsqueeze(-1)
+                .expand(T, self.n_group, scores.shape[-1] // self.n_group)
+                .reshape(T, -1)
+            )
+            scores_for_choice = scores_for_choice.masked_fill(
+                ~score_mask.bool(), float("-inf")
+            )
+
+        _, topk_idx = _topk_last_dim(scores_for_choice, self.top_k)
+        topk_weight = scores.gather(1, topk_idx)
+        if self.top_k > 1 and self.norm_topk_prob:
+            topk_weight = topk_weight / (
+                topk_weight.sum(dim=-1, keepdim=True) + 1e-20
+            )
+        topk_weight = topk_weight * self.routed_scaling_factor
+
+        affinities = torch.zeros_like(scores).scatter(1, topk_idx, topk_weight)
+        return affinities, topk_idx.to(torch.int32)
+
+    # ── Forward ──────────────────────────────────────────────────────────
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        is_decode: bool,
+        rank: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if is_decode:
+            return self.forward_decode(hidden_states, rank)
+        return self.forward_prefill(hidden_states, positions, rank)
+
+    def _ep_rank_tensor(self, rank: torch.Tensor | None, device) -> torch.Tensor:
+        """This rank's EP partition index, as a TRACED int32 scalar tensor.
+
+        ``self.ep_rank`` (a Python int captured at construction) must NOT reach
+        the graph: ``vllm_neuron.compile.backend`` sets ``per_rank=False``, so a
+        single NEFF is compiled once and executed on every TP rank. Baking in the
+        constructing rank's value would make all 64 ranks read rank 0's expert
+        window. The runner threads the TP-local rank in as a tensor input
+        (``neuron_model_runner.py`` ``self.rank_tensor``) precisely so this stays
+        dynamic; ``self.ep_rank`` is only for host-side weight loading, which
+        genuinely does run once per process.
+        """
+        if rank is None:
+            # CPU/component-test path: no rank input, single process.
+            return torch.tensor(self.ep_rank, dtype=torch.int32, device=device)
+        if self.ep_degree == 1:
+            return torch.zeros_like(rank).to(torch.int32)
+        return (
+            (rank % (self.ep_degree * self.tp_degree)) // self.tp_degree
+        ).to(torch.int32)
+
+    def _local_expert_slice(
+        self, affinities: torch.Tensor, rank: torch.Tensor | None
+    ) -> torch.Tensor:
+        """``[T, E]`` -> ``[T, E_local]`` for this EP rank."""
+        if self.ep_degree == 1:
+            return affinities
+        ep_rank = self._ep_rank_tensor(rank, affinities.device)
+        local_expert_indices = (
+            torch.arange(
+                self.num_local_experts,
+                device=affinities.device,
+                dtype=torch.int32,
+            )
+            + ep_rank * self.num_local_experts
+        )
+        return NF.get_local_expert_affinities(affinities, local_expert_indices)
+
+    def _gate_up_kernel_view(self) -> torch.Tensor:
+        return self.gate_up_proj_weight.reshape(
+            self.num_local_experts,
+            self.hidden_size,
+            2,
+            self.intermediate_size_per_rank,
+        )
+
+    def _prefill_block_size(self, num_tokens: int) -> int:
+        """MoE dispatch block size for a ``num_tokens``-long prefill.
+
+        The ``shard_on_block`` kernel faults on device with a "scatter/gather
+        (indirect memory copy via vector DGE) out-of-bound access" once the block
+        count grows past a threshold. Measured at TP=64/EP=64 (E_local=4,
+        top_k=8, so ``min(top_k, E_local) = 4`` local slots per token) with
+
+            N = ceil((T*4 - (E_local-1)) / block_size) + E_local - 1
+
+        | T    | block_size | N  | result |
+        |------|-----------:|---:|--------|
+        | 512  |        256 | 11 | ok     |
+        | 1024 |        512 | 11 | ok     |
+        | 1024 |        256 | 19 | FAULT  |
+        | 1024 |        128 | 35 | FAULT  |
+
+        N=11 is clean at both sequence lengths while N>=19 faults, and N=35
+        (whose per-shard count 18 IS divisible by the kernel's
+        BLOCK_PARALLEL_FACTOR of 3) faults too -- so the trigger is the block
+        count itself, not a divisibility condition on it. Solving N <= 11 for the
+        4-local-expert case gives ``block_size >= T/2``, hence the T//2 floor.
+        Forcing the torch mapping path (which is what builds the block table)
+        still faults, and forcing the torch MoE compute makes the fault vanish,
+        which is what localizes this to the dispatch kernel rather than to the
+        mapping or to attention.
+
+        The cost is real: a bigger block means more padding waste inside each
+        block, since a block holds one expert's tokens only. It is bounded
+        though, because ``skip_token=True`` turns padded rows' gathers into
+        no-op DMAs rather than compute.
+        """
+        # ceil(T/2), rounded up to a power of two so the block size stays a
+        # clean DMA granularity (T is a power-of-two bucket in practice, making
+        # this exactly T//2).
+        half = max(1, (num_tokens + 1) // 2)
+        return max(self.block_size, 1 << (half - 1).bit_length())
+
+    def forward_prefill(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        rank: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.to(self.dtype)
+
+        # Routing runs on this rank's SP shard, then affinities and hidden are
+        # gathered to the full sequence for the blockwise dispatch.
+        affinities = self._route(hidden_states)[0]
+        if self.tp_group.world_size > 1:
+            affinities = self.tp_group.all_gather(affinities, dim=0)
+            hidden_states = self.tp_group.all_gather(hidden_states, dim=0)
+
+        # Padding mask (True = real token). The runner right-pads the prompt to
+        # the bucket length with tokens whose positions REPEAT the last real
+        # position, so argmax finds the last real index. Without this mask the
+        # padding tokens are routed to experts, inflating the per-expert block
+        # count until the dispatch gather overruns the statically sized buffers
+        # (nrta-1006 at execute, invisible during warmup where every row is real).
+        padding_mask = None
+        if positions is not None:
+            last_real_idx = torch.argmax(positions)
+            token_indices = torch.arange(positions.shape[0], device=positions.device)
+            padding_mask = token_indices <= last_real_idx
+
+        affinities = self._local_expert_slice(affinities, rank)
+
+        # Sized from the (static, post-all-gather) token count so the dispatch
+        # kernel's block count stays inside the range it can address; see
+        # _prefill_block_size.
+        num_tokens = hidden_states.shape[0]
+        block_size = self._prefill_block_size(num_tokens)
+
+        (
+            expert_affinities_masked,
+            token_position_to_id,
+            block_to_expert,
+            conditions,
+        ) = NF.build_blockwise_mapping(
+            expert_affinities=affinities,
+            num_local_experts=self.num_local_experts,
+            num_experts_per_token=self.top_k,
+            block_size=block_size,
+            moe_group=self.ep_tp_group,
+            tp_degree=self.tp_degree,
+            padding_mask=padding_mask,
+        )
+
+        num_static_block = math.ceil(
+            num_tokens * self.top_k / self.ep_degree / block_size
+        )
+        # Bound the dispatch gather index to the valid hidden_states rows while
+        # PRESERVING the -1 padding sentinel that skip_token consumes.
+        token_position_to_id = token_position_to_id.clamp(min=-1, max=num_tokens - 1)
+
+        output = NF.moe_cte(
+            implementation=MoECTEImplementation.shard_on_block,
+            conditions=conditions,
+            hidden_states=hidden_states,
+            expert_affinities_masked=expert_affinities_masked,
+            gate_up_proj_weight=self._gate_up_kernel_view(),
+            down_proj_weight=self.down_proj_weight,
+            activation_function=ActFnType.SiLU,
+            # Must match the mapping's block_size exactly: the kernel recovers
+            # N as len(token_position_to_id) // block_size, so a mismatch
+            # silently reinterprets the block table.
+            block_size=block_size,
+            token_position_to_id=token_position_to_id.to(dtype=torch.int32),
+            block_to_expert=block_to_expert.to(dtype=torch.int32),
+            expert_affinities_scaling_mode=ExpertAffinityScaleMode.POST_SCALE,
+            skip_token=True,
+            # skip_weight=True is REQUIRED, not an optimization: shard_on_block
+            # over-allocates blocks (padding by +E-1 for per-expert rounding) and
+            # internally memsets the trailing padding blocks' expert ids to E —
+            # one past the valid [0, E-1] weight rows. With skip_weight=False
+            # that padding-block weight DMA runs in oob_mode.error and faults
+            # (nrta-1006); skip_weight flips it to oob_mode.skip.
+            skip_weight=True,
+            is_tensor_update_accumulating=True,
+            compute_dtype=nl.bfloat16,
+            num_static_block=num_static_block,
+        )
+
+        if self.moe_group.world_size > 1:
+            output = self.moe_group.reduce_scatter(output, dim=0)
+        # The fp32 router affinities promote the POST_SCALE multiply in the
+        # torch/meta path to fp32; cast back so the residual stream stays bf16.
+        return output.to(self.dtype)
+
+    def forward_decode(
+        self, hidden_states: torch.Tensor, rank: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        hidden_states = hidden_states.to(self.dtype)
+        affinities, expert_index = self._route(hidden_states)
+
+        if can_run_kernel(hidden_states):
+            rank_id = self._ep_rank_tensor(rank, hidden_states.device).reshape(1, 1)
+            output = NF.moe_tkg(
+                hidden_input=hidden_states,
+                expert_gate_up_weights=self._gate_up_kernel_view(),
+                expert_down_weights=self.down_proj_weight,
+                # Full [T, E] affinities; the kernel slices to this rank's
+                # [T, E_local] window using rank_id.
+                expert_affinities=affinities.to(self.dtype),
+                expert_index=expert_index,
+                is_all_expert=True,
+                rank_id=rank_id,
+                mask_unselected_experts=True,
+                expert_affinities_scaling_mode=ExpertAffinityScaleMode.POST_SCALE,
+                activation_fn=ActFnType.SiLU,
+                output_dtype=self.dtype,
+            )
+        else:
+            # ``NF.moe_tkg`` has no PyTorch fallback (it raises off-device), but
+            # CPU compile / component tests must still run the block.
+            output = self._experts_torch(hidden_states, affinities)
+
+        if self.moe_group.world_size > 1:
+            output = self.moe_group.all_reduce(output)
+        return output.to(self.dtype)
+
+    def _experts_torch(
+        self, hidden_states: torch.Tensor, affinities: torch.Tensor
+    ) -> torch.Tensor:
+        """Dense all-local-expert reference for CPU mode.
+
+        Equivalent to ``moe_tkg(is_all_expert=True, POST_SCALE)``: run every
+        local expert over every token and accumulate weighted by that token's
+        affinity for the expert (zero for unselected experts, so they drop out).
+        """
+        lo = self.ep_rank * self.num_local_experts
+        local_aff = affinities[:, lo : lo + self.num_local_experts].to(torch.float32)
+        gate_up = self._gate_up_kernel_view()  # [E_L, H, 2, I]
+        out = torch.zeros(
+            hidden_states.shape[0],
+            self.hidden_size,
+            dtype=torch.float32,
+            device=hidden_states.device,
+        )
+        for e in range(self.num_local_experts):
+            gate = hidden_states @ gate_up[e, :, 0, :]
+            up = hidden_states @ gate_up[e, :, 1, :]
+            expert_out = (F.silu(gate.float()) * up.float()) @ self.down_proj_weight[
+                e
+            ].float()
+            out = out + expert_out * local_aff[:, e : e + 1]
+        return out
+
+
+# =============================================================================
+# Section 6: Decoder Layer
+# =============================================================================
+
+
+class MiMoV2DecoderLayer(nn.Module):
+    """``norm -> attn -> +residual -> norm -> mlp -> +residual``.
+
+    Both layernorms are EXPLICIT members of the layer (they are not folded into
+    the MoE block, unlike the Qwen3.5 port) and both use the plain
+    :class:`MiMoV2RMSNorm`, matching ``MiMoV2DecoderLayer`` in HF.
+    """
+
+    def __init__(self, config: MiMoV2Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_moe = config.is_moe_layer(layer_idx)
+
+        self.input_layernorm = MiMoV2RMSNorm(
+            config.hidden_size, config.layernorm_epsilon, config.torch_dtype
+        )
+        self.self_attn = MiMoV2Attention(config, layer_idx)
+        self.post_attention_layernorm = MiMoV2RMSNorm(
+            config.hidden_size, config.layernorm_epsilon, config.torch_dtype
+        )
+        self.mlp = (
+            MiMoV2SparseMoeBlock(config) if self.is_moe else MiMoV2DenseMLP(config)
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: dict,
+        is_prefill: bool,
+        rank: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            positions=positions,
+            position_embeddings=position_embeddings,
+            attn_metadata=attn_metadata,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        if self.is_moe:
+            hidden_states = self.mlp(hidden_states, positions, not is_prefill, rank)
+        else:
+            hidden_states = self.mlp(hidden_states, not is_prefill)
+        return residual + hidden_states
+
+
+# =============================================================================
+# Section 7: Backbone
+# =============================================================================
+
+
+class MiMoV2Model(nn.Module):
+    """Embedding + hybrid decoder stack + final norm.
+
+    >>> PARALLELISM: SP <<<
+    Prefill scatters the sequence across TP ranks right out of the embedding
+    (``scatter_tokens=True``) and all-gathers after the final norm; decode runs
+    every token on every rank.
+    """
+
+    def __init__(self, config: MiMoV2Config):
+        super().__init__()
+        self.config = config
+
+        self.tp_group = get_tp_group()
+        self.world_size = self.tp_group.world_size
+        self.rank = self.tp_group.rank_in_group
+
+        self.embed_tokens = VocabDimShardedEmbedding(
+            vocab_size=config.vocab_size,
+            embed_dim=config.hidden_size,
+            dtype=config.torch_dtype,
+            tp_group=self.tp_group.device_group,
+        )
+        self.layers = nn.ModuleList(
+            [
+                MiMoV2DecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = MiMoV2RMSNorm(
+            config.hidden_size, config.layernorm_epsilon, config.torch_dtype
+        )
+
+        # <-- MODEL-SPECIFIC: two rotary caches, one per RoPE base.
+        self.rotary_emb = MiMoV2RotaryEmbedding(config, is_swa=False)
+        self.swa_rotary_emb = MiMoV2RotaryEmbedding(config, is_swa=True)
+
+        # No weight loader is set here: VocabDimShardedEmbedding installs its own
+        # (shard_dim=0, shard_size=vocab_size_per_rank, pad_shard=True), which is
+        # what we want -- vocab_size_per_rank is a ceil, so pad_shard matters for
+        # any TP degree that does not divide 152576 evenly.
+
+        # Index of the first full-attention layer; its metadata carries the
+        # untrimmed block table. Layer 0 is full in the released config, but
+        # read it from the pattern rather than assuming.
+        self.first_full_layer_idx = next(
+            (i for i in range(config.num_hidden_layers) if not config.is_swa_layer(i)),
+            0,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        positions: torch.Tensor,
+        attn_metadata: dict,
+        rank: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        is_token_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        layer_name = f"layers.{self.first_full_layer_idx}.self_attn"
+        max_query_len = attn_metadata[layer_name]["max_query_len"]
+        decode_token_threshold = attn_metadata[layer_name]["decode_token_threshold"]
+        is_prefill = max_query_len > decode_token_threshold
+
+        hidden_states = self.embed_tokens(
+            input_ids, scatter_tokens=is_prefill, rank=rank
+        )
+
+        # >>> PARALLELISM: shard prompt embeds to match the SP layout <<<
+        if (
+            is_prefill
+            and self.world_size > 1
+            and inputs_embeds is not None
+            and is_token_ids is not None
+        ):
+            local_len = hidden_states.shape[0]
+            start = self.rank * local_len
+            inputs_embeds = inputs_embeds[start : start + local_len]
+            is_token_ids = is_token_ids[start : start + local_len]
+
+        hidden_states = NF.merge_prompt_embeds(
+            hidden_states, inputs_embeds, is_token_ids
+        )
+
+        full_pe = self.rotary_emb(
+            positions, device=hidden_states.device, dtype=hidden_states.dtype
+        )
+        swa_pe = self.swa_rotary_emb(
+            positions, device=hidden_states.device, dtype=hidden_states.dtype
+        )
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                positions=positions,
+                position_embeddings=swa_pe if layer.self_attn.is_swa else full_pe,
+                attn_metadata=attn_metadata,
+                is_prefill=is_prefill,
+                rank=rank,
+            )
+
+        hidden_states = self.norm(hidden_states)
+
+        # >>> PARALLELISM: SP -> full sequence <<<
+        if is_prefill and self.world_size > 1:
+            hidden_states = self.tp_group.all_gather(hidden_states, dim=0)
+        return hidden_states
+
+
+# =============================================================================
+# Section 8: Language Model Head
+# =============================================================================
+
+
+class MiMoV2ForCausalLM(nn.Module):
+    """MiMo-V2.5 with a column-parallel LM head and on-device sampling."""
+
+    def __init__(self, config: MiMoV2Config):
+        super().__init__()
+        self.config = config
+        self.model = MiMoV2Model(config)
+
+        self.tp_group = get_tp_group()
+        self.world_size = self.tp_group.world_size
+        self.rank = self.tp_group.rank_in_group
+
+        nc = config.neuron_config
+        self.on_device_sampling_config = nc.on_device_sampling_config if nc else None
+        debug_logits_enabled = nc is not None and nc.debug_logits_dir is not None
+        self._gather_logits = (
+            nc is not None and nc.max_logprobs != 0
+        ) or debug_logits_enabled
+
+        self.lm_head = neuron_nn.ColumnParallelLinear(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=config.torch_dtype,
+            gather_output=not self.on_device_sampling_config,
+            tp_group=self.tp_group.device_group,
+        )
+        # ColumnParallelLinear installs its own row-sharding loader; no override.
+
+        if self.on_device_sampling_config is not None:
+            self.sampler = Sampler(
+                self.on_device_sampling_config,
+                process_group=self.tp_group.device_group,
+            )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+        is_token_ids: torch.Tensor | None = None,
+        attn_metadata: dict | None = None,
+        sampling_positions: torch.Tensor | None = None,
+        sampling_params: torch.Tensor | None = None,
+        spec_decode_metadata=None,
+        logit_mask: torch.Tensor | None = None,
+        rank: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        positions = positions.to(torch.int32)
+
+        layer_name = f"layers.{self.model.first_full_layer_idx}.self_attn"
+        max_query_len = attn_metadata[layer_name]["max_query_len"]
+        decode_token_threshold = attn_metadata[layer_name]["decode_token_threshold"]
+        is_prefill = max_query_len > decode_token_threshold
+
+        T = input_ids.shape[0]
+        if is_prefill and ((T <= self.world_size) or (T % self.world_size != 0)):
+            raise ValueError(
+                f"Prompt length ({T}) must be > world_size ({self.world_size}) "
+                f"and divisible by it for sequence parallelism."
+            )
+
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            attn_metadata=attn_metadata,
+            rank=rank,
+            inputs_embeds=inputs_embeds,
+            is_token_ids=is_token_ids,
+        )
+
+        hidden_states_for_logits = torch.index_select(
+            hidden_states, dim=0, index=sampling_positions
+        )
+        hidden_states_for_logits = hidden_states_for_logits.to(self.config.torch_dtype)
+        logits = self.lm_head(hidden_states_for_logits)
+
+        if self.on_device_sampling_config is None:
+            return logits
+
+        gathered_logits = None
+        if self._gather_logits:
+            gathered_logits = self.tp_group.all_gather(logits, dim=1)
+
+        sampled_tokens = self.sampler(
+            logits, sampling_params, logit_mask=logit_mask, tp_rank=rank
+        )
+
+        if spec_decode_metadata is not None:
+            from vllm_neuron.nn.rejection_sampler import rejection_sampler
+
+            return rejection_sampler(spec_decode_metadata, sampled_tokens)
+
+        return sampled_tokens, gathered_logits
+
+    @classmethod
+    def from_configs(cls, hf_config: PretrainedConfig, neuron_config: NeuronConfig):
+        config = MiMoV2Config.from_configs(hf_config, neuron_config)
+        _validate_parallelism(neuron_config)
+        return cls(config)
+
+    # ── KV cache ─────────────────────────────────────────────────────────
+
+    def get_kv_spec(self) -> KVSpec:
+        """One spec per layer; SWA layers declare their window.
+
+        ``head_size`` is the Q/K width (192) for BOTH caches — see
+        :class:`MiMoV2Attention` on why the 128-wide V is padded rather than
+        given its own size.
+        """
+        layers = []
+        for i, layer in enumerate(self.model.layers):
+            attn = layer.self_attn
+            layers.append(
+                LayerSpec(
+                    name=f"layers.{i}.self_attn",
+                    num_kv_heads=attn.num_key_value_heads_per_rank,
+                    head_size=attn.kv_cache_head_dim,
+                    dtype=attn.dtype,
+                    sliding_window_size=attn.sliding_window,
+                    chunk_size=None,
+                )
+            )
+        return KVSpec(layers=layers)
+
+    def bind_kv_cache(self, kv_caches: dict[str, list[torch.Tensor]]) -> None:
+        for i, layer in enumerate(self.model.layers):
+            layer_name = f"layers.{i}.self_attn"
+            if layer_name not in kv_caches:
+                raise KeyError(f"KV cache for layer {layer_name} not initialized")
+            layer.self_attn.k_cache = kv_caches[layer_name][0]
+            layer.self_attn.v_cache = kv_caches[layer_name][1]
+
+    # ── Weight loading ───────────────────────────────────────────────────
+
+    def _build_mappings(self, quantized: bool | None = None) -> dict:
+        """Map our parameter names to checkpoint keys.
+
+        The released checkpoint pairs every quantized weight with a
+        ``.weight_scale_inv`` companion, so those entries are 2-element lists
+        that the dequantizing loaders consume; an unquantized re-export drops
+        to 1-element lists and the same loaders take their bf16 branch.
+        MoE experts are separate keys per expert, listed INTERLEAVED
+        (``e0`` items, then ``e1`` items, ...) to match
+        ``expert_parallel_interleaved_loader``.
+
+        Args:
+            quantized: whether the checkpoint carries ``*_scale_inv`` companions.
+                ``None`` falls back to the config's ``quantization_config``,
+                which is absent when the serving path strips it (see
+                :meth:`_detect_quantized`).
+        """
+        cfg = self.config
+        if quantized is None:
+            quantized = cfg.is_fp8_checkpoint
+
+        def q(key: str) -> str | list[str]:
+            """Checkpoint entry for a possibly-quantized weight."""
+            return [key, f"{key}_scale_inv"] if quantized else key
+
+        mappings: dict = {
+            "model.embed_tokens.weight": "model.embed_tokens.weight",
+            "model.norm.weight": "model.norm.weight",
+            "lm_head.weight": "lm_head.weight",
+        }
+
+        for i in range(cfg.num_hidden_layers):
+            hf = f"model.layers.{i}"
+            ours = f"model.layers.{i}"
+
+            mappings[f"{ours}.input_layernorm.weight"] = f"{hf}.input_layernorm.weight"
+            mappings[f"{ours}.post_attention_layernorm.weight"] = (
+                f"{hf}.post_attention_layernorm.weight"
+            )
+
+            # Fused QKV: ONE pre-sharded tensor on disk (+ its scale grid).
+            mappings[f"{ours}.self_attn.qkv_proj_weight"] = q(
+                f"{hf}.self_attn.qkv_proj.weight"
+            )
+            # o_proj is in ignored_layers -> plain bf16, no scale companion.
+            mappings[f"{ours}.self_attn.o_proj_weight"] = f"{hf}.self_attn.o_proj.weight"
+            if self.model.layers[i].self_attn.attention_sink_bias is not None:
+                mappings[f"{ours}.self_attn.attention_sink_bias"] = (
+                    f"{hf}.self_attn.attention_sink_bias"
+                )
+
+            if cfg.is_moe_layer(i):
+                mappings[f"{ours}.mlp.router_weight"] = f"{hf}.mlp.gate.weight"
+                mappings[f"{ours}.mlp.e_score_correction_bias"] = (
+                    f"{hf}.mlp.gate.e_score_correction_bias"
+                )
+                gate_up: list[str] = []
+                down: list[str] = []
+                for e in range(cfg.n_routed_experts):
+                    ep = f"{hf}.mlp.experts.{e}"
+                    for proj in ("gate_proj", "up_proj"):
+                        key = f"{ep}.{proj}.weight"
+                        gate_up.append(key)
+                        if quantized:
+                            gate_up.append(f"{key}_scale_inv")
+                    key = f"{ep}.down_proj.weight"
+                    down.append(key)
+                    if quantized:
+                        down.append(f"{key}_scale_inv")
+                mappings[f"{ours}.mlp.gate_up_proj_weight"] = gate_up
+                mappings[f"{ours}.mlp.down_proj_weight"] = down
+            else:
+                mappings[f"{ours}.mlp.gate_proj_weight"] = q(f"{hf}.mlp.gate_proj.weight")
+                mappings[f"{ours}.mlp.up_proj_weight"] = q(f"{hf}.mlp.up_proj.weight")
+                mappings[f"{ours}.mlp.down_proj_weight"] = q(f"{hf}.mlp.down_proj.weight")
+
+        return mappings
+
+    def _detect_quantized(self, checkpoint: SafetensorsCheckpoint) -> bool:
+        """Decide fp8-vs-bf16 from the CHECKPOINT, not from ``config.json``.
+
+        vLLM auto-derives ``quantization`` from ``hf_config.quantization_config``
+        and then rejects "fp8" against the platform's allowlist
+        (``neuron_quant`` / ``compressed-tensors`` / ``modelopt``), so the serving
+        path has to strip that key via ``hf_overrides``. Deriving the loader
+        branch from the same stripped config would then silently pick the bf16
+        branch and read raw fp8 bytes as bf16 -- garbage, with no error. The
+        presence of a ``*_scale_inv`` companion is the ground truth.
+
+        Nothing else in the load path needs the stripped key: the 128x128 tile
+        shape is the loaders' own constant, and ``o_proj``'s unquantized-ness is
+        expressed structurally (its mapping never carries a scale companion)
+        rather than by consulting ``ignored_layers``.
+        """
+        checkpoint._ensure_indexed()
+        names = checkpoint.get_tensor_names()
+        probe = (
+            f"model.layers.{self.model.first_full_layer_idx}"
+            ".self_attn.qkv_proj.weight_scale_inv"
+        )
+        quantized = probe in names
+        if quantized != self.config.is_fp8_checkpoint:
+            logger.info(
+                "MiMo-V2.5: checkpoint fp8=%s (probed %s), config said %s; "
+                "trusting the checkpoint.",
+                quantized,
+                probe,
+                self.config.is_fp8_checkpoint,
+            )
+        # No-op where the branch already matches, so this is unconditional.
+        for layer in self.model.layers:
+            layer.mlp.set_quantized(quantized)
+        return quantized
+
+    def _resolve_qkv_disk_tp(
+        self, checkpoint: SafetensorsCheckpoint, quantized: bool
+    ) -> None:
+        """Pin the fused-QKV on-disk shard count, then reinstall the qkv loaders.
+
+        ``from_configs`` never receives the checkpoint path, so this cannot be
+        settled at construction; it has to happen here, before the first slice is
+        read. A FULL-attention layer's grid is unambiguous (nkv=4 -> the K and V
+        sections ceil-pad, so 4 shards give 108 scale rows where 1 gives 106),
+        whereas an SWA layer's is not (nkv=8 -> 116 rows for 1, 2 and 4 alike).
+        Probe a full layer, then hand the answer to every layer's loader.
+
+        An explicit ``config.qkv_disk_tp`` wins, and a bf16 re-export has no
+        scale grid at all to probe, so both short-circuit.
+        """
+        if not quantized:
+            return
+
+        disk_tp = self.config.qkv_disk_tp
+        if disk_tp is None:
+            probe_layer = self.model.first_full_layer_idx
+            attn = self.model.layers[probe_layer].self_attn
+            if attn.is_swa:
+                # Every layer is SWA: nothing to probe. Leave the loaders on
+                # per-tensor inference, which raises rather than guessing.
+                logger.warning(
+                    "MiMo-V2.5: no full-attention layer to probe for the "
+                    "fused-QKV disk shard count; set config.qkv_disk_tp if "
+                    "loading raises on an ambiguous scale grid."
+                )
+                return
+            checkpoint._ensure_indexed()
+            scale_name = (
+                f"model.layers.{probe_layer}.self_attn.qkv_proj.weight_scale_inv"
+            )
+            scale_rows = int(checkpoint._get_slice(scale_name).get_shape()[0])
+            disk_tp = infer_qkv_disk_tp(
+                scale_rows,
+                attn.num_attention_heads,
+                attn.num_key_value_heads,
+                attn.head_dim,
+                attn.v_head_dim,
+            )
+            logger.info(
+                "MiMo-V2.5: fused-QKV disk shard count = %d "
+                "(probed layer %d, %d scale rows)",
+                disk_tp,
+                probe_layer,
+                scale_rows,
+            )
+
+        for layer in self.model.layers:
+            layer.self_attn.set_qkv_disk_tp(disk_tp)
+
+    def load_weights(
+        self, checkpoint_path: str, device: torch.device, cache_dir: str | None
+    ) -> None:
+        checkpoint = SafetensorsCheckpoint(checkpoint_path, cache_dir)
+        quantized = self._detect_quantized(checkpoint)
+        logger.info(
+            "MiMo-V2.5 load_weights: rank=%d world_size=%d fp8_checkpoint=%s",
+            self.rank,
+            self.world_size,
+            quantized,
+        )
+        self._resolve_qkv_disk_tp(checkpoint, quantized)
+        state_dict = checkpoint.load_sharded_pipelined(
+            self.rank,
+            self.world_size,
+            self,
+            self._build_mappings(quantized=quantized),
+            device,
+        ).state_dict
+        self.load_state_dict(state_dict, strict=False, assign=True)
+
+    def load_weights_lite(
+        self, checkpoint_path: str, device: torch.device, cache_dir: str | None
+    ) -> None:
+        """Lightweight path used during CPU compile (index only, no tensors)."""
+        checkpoint = SafetensorsCheckpoint(checkpoint_path, cache_dir)
+        checkpoint._ensure_indexed()
+
+
+def _validate_parallelism(neuron_config: NeuronConfig | None) -> None:
+    """Reject the DP modes this port has not been wired for.
+
+    Attention/MLP/embedding/LM-head data parallelism needs per-module DP group
+    transitions and a DP-aware effective rank in every weight loader (see
+    ``gpt_oss/model_bf16.py``). None of that is implemented here, and silently
+    running with DP > 1 would shard weights against the wrong rank.
+    """
+    if neuron_config is None:
+        return
+    for field in (
+        "attention_dp_size",
+        "mlp_dp_size",
+        "embedding_dp_size",
+        "lm_head_dp_size",
+    ):
+        size = getattr(neuron_config, field, 1) or 1
+        if size > 1:
+            raise ValueError(
+                f"MiMo-V2.5 does not support {field}={size}; only TP + SP + EP "
+                f"are implemented. Set {field}=1."
+            )

--- a/vllm_neuron/model/mimo_v2_5/model.py
+++ b/vllm_neuron/model/mimo_v2_5/model.py
@@ -1309,6 +1309,24 @@ class MiMoV2SparseMoeBlock(nn.Module):
 
         if can_run_kernel(hidden_states):
             rank_id = self._ep_rank_tensor(rank, hidden_states.device).reshape(1, 1)
+            # Static all-expert dispatch, deliberately. The two alternatives were
+            # both measured on device and both lose:
+            #
+            #   - ``is_all_expert=False`` (routed/selective) indexes the LOCAL
+            #     [E_L, H, 2, I] weights with the GLOBAL expert id and takes no
+            #     rank_id, so it is EP-incompatible by construction (which is why
+            #     gpt_oss/model_bf16.py force-enables all-expert when ep_degree>1).
+            #     It also does K=8 experts of work per token against all-expert's
+            #     E_local=4, and does not compile at these dims.
+            #   - ``is_all_expert_dynamic=True`` skips token blocks with no routed
+            #     tokens, and in an isolated single-kernel microbenchmark that
+            #     looked like a 1.2-1.55x win at T>=16 (bit-exact). END TO END IT
+            #     IS SLOWER: median ITL 160.6/152.9/148.1 ms at concurrency
+            #     1/16/32 versus 147.2/147.2/147.1 static, same host, same
+            #     recompile. The microbenchmark measured one kernel per host round
+            #     trip; in the real graph these are 47 back-to-back invocations
+            #     and the data-dependent control flow (nl.dynamic_range +
+            #     _find_routed_tokens) costs more than the skipping saves.
             output = NF.moe_tkg(
                 hidden_input=hidden_states,
                 expert_gate_up_weights=self._gate_up_kernel_view(),

--- a/vllm_neuron/model/mimo_v2_5/weight_loaders_bf16.py
+++ b/vllm_neuron/model/mimo_v2_5/weight_loaders_bf16.py
@@ -1,0 +1,509 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiMo-V2.5 weight loaders (FP8-blockwise checkpoint -> BF16 runtime).
+
+The released base checkpoint stores nearly every matmul weight as
+``float8_e4m3`` with a companion ``*.weight_scale_inv`` tensor holding one
+fp32 scale per ``128 x 128`` tile (``quantization_config.weight_block_size``).
+``config.dtype`` is ``bfloat16`` — that is the COMPUTE dtype, not the storage
+dtype. This port runs BF16 end to end, so every loader here dequantizes
+host-side inside the ``SafetensorsWeightLoader`` transform and returns BF16.
+
+Two distinct on-disk scale-grid layouts exist and they are NOT interchangeable:
+
+1. **Plain / flat grid** — used by every weight except the fused QKV. A weight
+   of shape ``[R, C]`` pairs with a scale of shape
+   ``[ceil(R/128), ceil(C/128)]``; tile ``(i, j)`` scales rows
+   ``[128i, 128i+128)`` x cols ``[128j, 128j+128)``. Verified against the
+   checkpoint: ``mlp.gate_proj [16384, 4096] <-> [128, 32]``,
+   ``mlp.down_proj [4096, 16384] <-> [32, 128]``,
+   ``experts.N.gate_proj [2048, 4096] <-> [16, 32]``,
+   ``experts.N.down_proj [4096, 2048] <-> [32, 16]``.
+
+2. **Pre-sharded fused QKV** — ``self_attn.qkv_proj.weight`` is stored as
+   ``disk_tp`` CONCATENATED tensor-parallel shards, each shard laid out as
+   ``[Q rows | K rows | V rows]``, and each of those three sections gets its
+   OWN ceil-padded 128-row scale grid. That padding is why the scale row count
+   does not match a naive ``ceil(total_rows / 128)``:
+
+       full-attn layer (nh=64, nkv=4, hd=192, vhd=128), disk_tp=4
+         per-shard rows   = 16*192 + 1*192 + 1*128 = 3392  (x4 = 13568 ✓)
+         per-shard blocks = 24     + 2     + 1     = 27    (x4 = 108   ✓)
+       SWA layer (nkv=8)
+         per-shard rows   = 16*192 + 2*192 + 2*128 = 3712  (x4 = 14848 ✓)
+         per-shard blocks = 24     + 3     + 2     = 29    (x4 = 116   ✓)
+
+   A naive flat grid would give 106 / 112 rows respectively, so treating this
+   tensor as layout (1) silently mis-scales most of Q. ``disk_tp`` is recovered
+   from the scale row count (the weight shape alone is invariant to it), so a
+   re-sharded or unsharded re-export loads correctly too.
+
+All loaders read only the tiles they need: the fused-QKV loader touches just
+the 128-row blocks covering this rank's heads (~2 blocks of Q instead of the
+whole 3072-row Q section), and the TP-sharded MLP loaders slice before
+dequantizing.
+"""
+
+import math
+
+import torch
+
+from vllm_neuron.utils.weight_loader import SafetensorsWeightLoader
+
+FP8_BLOCK = 128
+
+
+# =============================================================================
+# Blockwise FP8 dequantization primitives (host-side, load time only)
+# =============================================================================
+
+
+def _scale_row_to_width(scale_row: torch.Tensor, width: int, block_k: int) -> torch.Tensor:
+    """Expand one scale-grid row to a per-column scale vector of length ``width``.
+
+    ``repeat_interleave`` here runs on a ~32-element CPU tensor at load time
+    (never traced), and the trailing ``[:width]`` handles a ceil-padded final
+    column block.
+    """
+    return scale_row.reshape(-1).to(torch.float32).repeat_interleave(block_k)[:width]
+
+
+def dequant_fp8_blockwise(
+    w_slice,
+    s_slice,
+    row_range: tuple[int, int] | None = None,
+    col_range: tuple[int, int] | None = None,
+    block: tuple[int, int] = (FP8_BLOCK, FP8_BLOCK),
+) -> torch.Tensor:
+    """Dequantize a flat-grid blockwise-FP8 2-D tensor to fp32.
+
+    Args:
+        w_slice: checkpoint slice of the ``[R, C]`` fp8 weight.
+        s_slice: checkpoint slice of the ``[ceil(R/bm), ceil(C/bk)]`` fp32 scale.
+        row_range: optional ``[lo, hi)`` row window (e.g. a TP shard). Only the
+            128-row blocks intersecting it are read; the result is trimmed to
+            exactly ``hi - lo`` rows, so an unaligned window is still correct.
+        col_range: optional ``[lo, hi)`` column window.
+        block: ``(block_m, block_k)`` tile shape.
+
+    Returns:
+        fp32 tensor of shape ``[hi_r - lo_r, hi_c - lo_c]``.
+    """
+    R, C = tuple(w_slice.get_shape())
+    r0, r1 = row_range if row_range is not None else (0, R)
+    c0, c1 = col_range if col_range is not None else (0, C)
+    block_m, block_k = block
+
+    first_blk = r0 // block_m
+    last_blk = (r1 - 1) // block_m
+
+    parts = []
+    for bi in range(first_blk, last_blk + 1):
+        rr0 = bi * block_m
+        rr1 = min(rr0 + block_m, R)
+        w = w_slice[rr0:rr1, c0:c1].to(torch.float32)
+        scale_full = _scale_row_to_width(s_slice[bi : bi + 1], C, block_k)
+        parts.append(w * scale_full[c0:c1].view(1, -1))
+
+    out = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
+    offset = first_blk * block_m
+    return out[r0 - offset : r1 - offset]
+
+
+def _dequant_section_rows(
+    w_slice,
+    s_slice,
+    row_lo: int,
+    row_hi: int,
+    sec_row_start: int,
+    sec_row_end: int,
+    sec_blk_start: int,
+    block_m: int = FP8_BLOCK,
+    block_k: int = FP8_BLOCK,
+) -> torch.Tensor:
+    """Dequantize absolute rows ``[row_lo, row_hi)`` inside ONE fused-QKV section.
+
+    The section spans absolute rows ``[sec_row_start, sec_row_end)`` and its
+    scale grid starts at scale row ``sec_blk_start``. Block indices are relative
+    to the section (that is exactly what "each section gets its own ceil-padded
+    grid" means), so they must not be computed from the absolute row number.
+    """
+    first_blk = (row_lo - sec_row_start) // block_m
+    last_blk = (row_hi - 1 - sec_row_start) // block_m
+
+    C = int(w_slice.get_shape()[1])
+    parts = []
+    for bi in range(first_blk, last_blk + 1):
+        rr0 = sec_row_start + bi * block_m
+        rr1 = min(rr0 + block_m, sec_row_end)
+        w = w_slice[rr0:rr1].to(torch.float32)
+        scale_full = _scale_row_to_width(
+            s_slice[sec_blk_start + bi : sec_blk_start + bi + 1], C, block_k
+        )
+        parts.append(w * scale_full.view(1, -1))
+
+    out = torch.cat(parts, dim=0) if len(parts) > 1 else parts[0]
+    offset = sec_row_start + first_blk * block_m
+    return out[row_lo - offset : row_hi - offset]
+
+
+# =============================================================================
+# Fused QKV (pre-sharded on disk, per-section ceil-padded scale grid)
+# =============================================================================
+
+
+def _qkv_section_geometry(disk_tp: int, nh: int, nkv: int, hd: int, vhd: int):
+    """Per-disk-shard row / scale-block geometry of one fused-QKV tensor."""
+    q_rows = (nh // disk_tp) * hd
+    k_rows = (nkv // disk_tp) * hd
+    v_rows = (nkv // disk_tp) * vhd
+    q_blks = math.ceil(q_rows / FP8_BLOCK)
+    k_blks = math.ceil(k_rows / FP8_BLOCK)
+    v_blks = math.ceil(v_rows / FP8_BLOCK)
+    return (
+        q_rows,
+        k_rows,
+        v_rows,
+        q_rows + k_rows + v_rows,
+        q_blks,
+        k_blks,
+        v_blks,
+        q_blks + k_blks + v_blks,
+    )
+
+
+def qkv_disk_tp_candidates(
+    scale_rows: int, nh: int, nkv: int, hd: int, vhd: int
+) -> list[int]:
+    """Shard counts whose per-section scale grid totals ``scale_rows`` rows."""
+    candidates = [
+        d for d in (1, 2, 4, 8, 16, 32, 64) if nh % d == 0 and nkv % d == 0
+    ]
+    return [
+        d
+        for d in candidates
+        if d * _qkv_section_geometry(d, nh, nkv, hd, vhd)[7] == scale_rows
+    ]
+
+
+def infer_qkv_disk_tp(scale_rows: int, nh: int, nkv: int, hd: int, vhd: int) -> int:
+    """Recover the checkpoint's fused-QKV shard count from its scale row count.
+
+    The weight row count (``nh*hd + nkv*hd + nkv*vhd``) is independent of
+    ``disk_tp``, but the ceil-padded per-section scale grid usually is: 4 shards
+    of a MiMo full-attn layer (nkv=4) give 108 scale rows where 1 shard would
+    give 106, so that layer pins the value.
+
+    NOT every layer does. When every section is already 128-divisible the
+    padding vanishes and the total is shard-count invariant — MiMo's SWA layers
+    (nkv=8) give 116 rows for disk_tp in {1, 2, 4} alike, even though the row
+    ORDER differs ([Q0 K0 V0][Q1 K1 V1]... vs one [Q|K|V]). Such a layer cannot
+    be resolved from its own shapes; pass ``disk_tp`` explicitly (the checkpoint
+    index's ``metadata.tp_size``, which :class:`MiMoV2Config` picks up as
+    ``qkv_disk_tp``).
+    """
+    matches = qkv_disk_tp_candidates(scale_rows, nh, nkv, hd, vhd)
+    if len(matches) != 1:
+        raise ValueError(
+            f"cannot infer fused-QKV disk shard count from scale_rows={scale_rows} "
+            f"(nh={nh}, nkv={nkv}, head_dim={hd}, v_head_dim={vhd}); "
+            f"candidates matching: {matches}. Pass disk_tp explicitly (see "
+            f"MiMoV2Config.qkv_disk_tp / the checkpoint index's metadata.tp_size)."
+        )
+    return matches[0]
+
+
+def fused_qkv_fp8_loader(
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    num_shards: int,
+    num_kv_replicas: int = 1,
+    dtype: torch.dtype = torch.bfloat16,
+    disk_tp: int | None = None,
+) -> SafetensorsWeightLoader:
+    """Load one rank's slice of a pre-sharded blockwise-FP8 fused QKV weight.
+
+    The framework's :func:`fused_qkv_weight_loader` cannot serve this tensor: it
+    asserts three separate q/k/v checkpoint slices, while MiMo ships ONE fused
+    tensor that is additionally pre-sharded across ``disk_tp`` ranks with a
+    per-section scale grid.
+
+    Args:
+        num_attention_heads: global Q head count.
+        num_key_value_heads: global KV head count.
+        head_dim: Q/K head width (192).
+        v_head_dim: V head width (128).
+        num_shards: runtime TP degree (may differ from the checkpoint's).
+        num_kv_replicas: how many consecutive ranks share one KV head. Set when
+            ``num_shards >= num_key_value_heads`` so every rank holds exactly one
+            KV head instead of a zero-width slice.
+        dtype: runtime dtype of the returned parameter.
+        disk_tp: the checkpoint's own shard count. REQUIRED whenever the scale
+            grid is shard-count invariant (MiMo's SWA layers, nkv=8: 116 rows
+            for disk_tp 1, 2 and 4 alike) — inference cannot distinguish those,
+            and guessing wrong permutes the head rows. Read it from the
+            checkpoint index (``metadata.tp_size``); ``None`` falls back to
+            :func:`infer_qkv_disk_tp`, which raises on an ambiguous grid rather
+            than picking a candidate.
+
+    Returns:
+        Loader producing ``[hidden, q_local*hd + kv_local*hd + kv_local*vhd]``
+        (transposed relative to the checkpoint's row-major Linear layout, which
+        is what :func:`vllm_neuron.functional.qkv_proj` consumes).
+    """
+    nh, nkv, hd, vhd = num_attention_heads, num_key_value_heads, head_dim, v_head_dim
+    declared_disk_tp = disk_tp
+
+    def transform(slices: list, rank: int) -> torch.Tensor:
+        if len(slices) == 1:
+            # BF16 (or otherwise unquantized) re-export: no scale grid exists,
+            # so nothing can be inferred. Trust the declared value; default to
+            # the canonical HF single unsharded [Q|K|V] tensor.
+            w_slice, s_slice = slices[0], None
+            disk_tp = declared_disk_tp if declared_disk_tp is not None else 1
+        elif len(slices) == 2:
+            w_slice, s_slice = slices
+            scale_rows = int(s_slice.get_shape()[0])
+            if declared_disk_tp is not None:
+                # Cross-check rather than trust blindly: a declared value that
+                # contradicts the grid means the checkpoint was re-sharded and
+                # the index metadata went stale.
+                allowed = qkv_disk_tp_candidates(scale_rows, nh, nkv, hd, vhd)
+                if declared_disk_tp not in allowed:
+                    raise ValueError(
+                        f"declared disk_tp={declared_disk_tp} is inconsistent with "
+                        f"the fused-QKV scale grid ({scale_rows} rows for nh={nh}, "
+                        f"nkv={nkv}); grid admits {allowed}"
+                    )
+                disk_tp = declared_disk_tp
+            else:
+                disk_tp = infer_qkv_disk_tp(scale_rows, nh, nkv, hd, vhd)
+        else:
+            raise ValueError(
+                f"fused_qkv_fp8_loader expects 1 (bf16) or 2 (fp8 + scale) "
+                f"slices, got {len(slices)}"
+            )
+
+        (q_rows, k_rows, _v_rows, shard_rows, q_blks, k_blks, _v_blks, shard_blks) = (
+            _qkv_section_geometry(disk_tp, nh, nkv, hd, vhd)
+        )
+
+        tp_rank = rank % num_shards
+        q_per_rank = nh // num_shards
+        kv_per_rank = max(nkv // num_shards, 1)
+
+        # Which global heads does this rank own?
+        q_head_lo = tp_rank * q_per_rank
+        if num_kv_replicas > 1:
+            # Every rank holds ONE replicated KV head; consecutive groups of
+            # num_kv_replicas ranks share it (matches the runtime geometry in
+            # MiMoV2Attention.__init__).
+            kv_head_lo = tp_rank // num_kv_replicas
+            kv_per_rank = 1
+        else:
+            kv_head_lo = tp_rank * kv_per_rank
+
+        q_per_disk_shard = nh // disk_tp
+        kv_per_disk_shard = nkv // disk_tp
+
+        def _read(section: str, head_idx: int) -> torch.Tensor:
+            """Dequantize one logical head's rows from whichever disk shard holds it."""
+            if section == "q":
+                ds = head_idx // q_per_disk_shard
+                local = head_idx % q_per_disk_shard
+                sec_start = ds * shard_rows
+                width, sec_blk = hd, ds * shard_blks
+            elif section == "k":
+                ds = head_idx // kv_per_disk_shard
+                local = head_idx % kv_per_disk_shard
+                sec_start = ds * shard_rows + q_rows
+                width, sec_blk = hd, ds * shard_blks + q_blks
+            else:  # "v"
+                ds = head_idx // kv_per_disk_shard
+                local = head_idx % kv_per_disk_shard
+                sec_start = ds * shard_rows + q_rows + k_rows
+                width, sec_blk = vhd, ds * shard_blks + q_blks + k_blks
+
+            sec_len = (
+                q_per_disk_shard * hd
+                if section == "q"
+                else kv_per_disk_shard * (hd if section == "k" else vhd)
+            )
+            lo = sec_start + local * width
+            hi = lo + width
+            if s_slice is None:
+                return w_slice[lo:hi].to(torch.float32)
+            return _dequant_section_rows(
+                w_slice,
+                s_slice,
+                row_lo=lo,
+                row_hi=hi,
+                sec_row_start=sec_start,
+                sec_row_end=sec_start + sec_len,
+                sec_blk_start=sec_blk,
+            )
+
+        rows = []
+        for h in range(q_head_lo, q_head_lo + q_per_rank):
+            rows.append(_read("q", h))
+        for j in range(kv_head_lo, kv_head_lo + kv_per_rank):
+            rows.append(_read("k", j))
+        for j in range(kv_head_lo, kv_head_lo + kv_per_rank):
+            rows.append(_read("v", j))
+
+        fused = torch.cat(rows, dim=0)  # [fused_qkv_dim, hidden]
+        return fused.T.contiguous().to(dtype)  # [hidden, fused_qkv_dim]
+
+    return SafetensorsWeightLoader(transform=transform)
+
+
+# =============================================================================
+# Dense MLP (layer 0) — flat scale grid, TP-sharded on the intermediate dim
+# =============================================================================
+
+
+def dense_gate_up_fp8_loader(
+    shard_size: int, num_shards: int, dtype: torch.dtype = torch.bfloat16
+) -> SafetensorsWeightLoader:
+    """HF ``[I, H]`` fp8 -> our ``[H, I/TP]`` bf16 (gate_proj / up_proj)."""
+
+    def transform(slices: list, rank: int) -> torch.Tensor:
+        tp_rank = rank % num_shards
+        lo = tp_rank * shard_size
+        rows = (lo, lo + shard_size)
+        if len(slices) == 1:
+            w = slices[0][rows[0] : rows[1], :]
+        else:
+            w = dequant_fp8_blockwise(slices[0], slices[1], row_range=rows)
+        return w.T.contiguous().to(dtype)
+
+    return SafetensorsWeightLoader(transform=transform)
+
+
+def dense_down_fp8_loader(
+    shard_size: int, num_shards: int, dtype: torch.dtype = torch.bfloat16
+) -> SafetensorsWeightLoader:
+    """HF ``[H, I]`` fp8 -> our ``[I/TP, H]`` bf16 (down_proj, row-parallel)."""
+
+    def transform(slices: list, rank: int) -> torch.Tensor:
+        tp_rank = rank % num_shards
+        lo = tp_rank * shard_size
+        cols = (lo, lo + shard_size)
+        if len(slices) == 1:
+            w = slices[0][:, cols[0] : cols[1]]
+        else:
+            w = dequant_fp8_blockwise(slices[0], slices[1], col_range=cols)
+        return w.T.contiguous().to(dtype)
+
+    return SafetensorsWeightLoader(transform=transform)
+
+
+# =============================================================================
+# MoE experts — per-expert keys, flat scale grid
+# =============================================================================
+# MiMo stores experts as SEPARATE keys per expert
+# (``mlp.experts.{e}.{gate,up,down}_proj.weight`` + ``.weight_scale_inv``), so
+# the parameter's checkpoint mapping is a flat INTERLEAVED list and the EP
+# wrapper is :func:`expert_parallel_interleaved_loader`. That wrapper slices the
+# list down to this rank's experts before calling the transform, so ``E_local``
+# is derived from the slice count here — never from ``n_routed_experts``.
+#
+# ``quantized`` is passed in from ``MiMoV2Config.is_fp8_checkpoint`` rather than
+# sniffed from slice shapes: it decides the items-per-expert stride, and reading
+# that wrong silently mis-groups every expert's tensors.
+
+
+def _local_expert_count(n_slices: int, items_per_expert: int, kind: str) -> int:
+    if n_slices % items_per_expert != 0:
+        raise ValueError(
+            f"{kind} loader expects len(slices) divisible by {items_per_expert}, "
+            f"got {n_slices}"
+        )
+    return n_slices // items_per_expert
+
+
+def expert_gate_up_fp8_loader(
+    shard_size: int,
+    num_shards: int,
+    quantized: bool = True,
+    dtype: torch.dtype = torch.bfloat16,
+) -> SafetensorsWeightLoader:
+    """Fuse + dequantize per-expert gate/up into ``[E_L, H, 2*I/TP]``.
+
+    Args:
+        shard_size: ``2 * intermediate_size_per_rank``. The kernel reshapes the
+            result to ``[E_L, H, 2, I/TP]``, so gate must occupy the first half
+            of the last dim.
+        num_shards: MoE tensor-parallel degree.
+        quantized: when True ``slices`` is ``[gate_w, gate_scale, up_w,
+            up_scale, ...]`` (4 items/expert); when False ``[gate_w, up_w, ...]``.
+        dtype: runtime dtype of the returned parameter.
+    """
+    items = 4 if quantized else 2
+
+    def transform(slices: list, rank: int) -> torch.Tensor:
+        n_experts = _local_expert_count(len(slices), items, "expert_gate_up")
+
+        tp_rank = rank % num_shards
+        half = shard_size // 2  # intermediate_size_per_rank
+        rows = (tp_rank * half, tp_rank * half + half)
+
+        per_expert = []
+        for e in range(n_experts):
+            base = e * items
+            if quantized:
+                gate = dequant_fp8_blockwise(
+                    slices[base], slices[base + 1], row_range=rows
+                )
+                up = dequant_fp8_blockwise(
+                    slices[base + 2], slices[base + 3], row_range=rows
+                )
+            else:
+                gate = slices[base][rows[0] : rows[1], :]
+                up = slices[base + 1][rows[0] : rows[1], :]
+            fused = torch.cat([gate, up], dim=0)  # [2*I/TP, H]
+            per_expert.append(fused.T.contiguous())  # [H, 2*I/TP]
+
+        return torch.stack(per_expert, dim=0).to(dtype)  # [E_L, H, 2*I/TP]
+
+    return SafetensorsWeightLoader(transform=transform)
+
+
+def expert_down_fp8_loader(
+    shard_size: int,
+    num_shards: int,
+    quantized: bool = True,
+    dtype: torch.dtype = torch.bfloat16,
+) -> SafetensorsWeightLoader:
+    """Dequantize per-expert down_proj into ``[E_L, I/TP, H]``.
+
+    Args:
+        shard_size: ``intermediate_size_per_rank``.
+        num_shards: MoE tensor-parallel degree.
+        quantized: when True ``slices`` is ``[down_w, down_scale, ...]``
+            (2 items/expert); when False ``[down_w, ...]``.
+        dtype: runtime dtype of the returned parameter.
+    """
+    items = 2 if quantized else 1
+
+    def transform(slices: list, rank: int) -> torch.Tensor:
+        n_experts = _local_expert_count(len(slices), items, "expert_down")
+
+        tp_rank = rank % num_shards
+        cols = (tp_rank * shard_size, tp_rank * shard_size + shard_size)
+
+        per_expert = []
+        for e in range(n_experts):
+            base = e * items
+            if quantized:
+                w = dequant_fp8_blockwise(
+                    slices[base], slices[base + 1], col_range=cols
+                )  # [H, I/TP]
+            else:
+                w = slices[base][:, cols[0] : cols[1]]
+            per_expert.append(w.T.contiguous())  # [I/TP, H]
+
+        return torch.stack(per_expert, dim=0).to(dtype)  # [E_L, I/TP, H]
+
+    return SafetensorsWeightLoader(transform=transform)

--- a/vllm_neuron/model/registry.py
+++ b/vllm_neuron/model/registry.py
@@ -4,6 +4,7 @@ import os
 from .llama3 import LlamaForCausalLM
 from .gpt_oss import GptOssForCausalLM
 from .llama3 import Eagle3LlamaForCausalLM
+from .mimo_v2_5 import MiMoV2ForCausalLM
 from .qwen3_vl import Qwen3VLForConditionalGeneration
 
 
@@ -20,6 +21,7 @@ def get_models() -> list[tuple[str, type]]:
         ("LlamaForCausalLM", LlamaForCausalLM),
         ("GptOssForCausalLM", GptOssForCausalLM),
         ("Eagle3LlamaForCausalLM", Eagle3LlamaForCausalLM),
+        ("MiMoV2ForCausalLM", MiMoV2ForCausalLM),
         ("Qwen3VLForConditionalGeneration", Qwen3VLForConditionalGeneration),
     ]
 

--- a/vllm_neuron/vllm/platform.py
+++ b/vllm_neuron/vllm/platform.py
@@ -195,6 +195,37 @@ class NeuronPlatform(Platform):
             logger.info("Defaulting optimization level to O1 on Neuron")
 
     @classmethod
+    def _mm_disabled(cls, model_config) -> bool:
+        """True if no request to this model can carry multimodal input.
+
+        Two ways that happens:
+
+        1. ``model_config.multimodal_config is None`` -- vLLM only builds it for
+           models the registry classifies as multimodal, so ``None`` means the
+           whole multimodal path is inert. This is the case that matters for a
+           text-only checkpoint whose custom ``configuration_*.py`` sets
+           ``self.vision_config`` anyway (MiMo-V2.5 does).
+        2. Every declared per-prompt limit is 0, i.e.
+           ``--limit-mm-per-prompt '{"image":0,"video":0,"audio":0}'``. An empty
+           mapping on a genuinely multimodal model means "defaults apply", which
+           is NOT disabled.
+
+        For case 2, read through ``multimodal_config``: ``ModelConfig`` takes
+        ``limit_mm_per_prompt`` as an ``InitVar``, so it is not an attribute
+        after construction -- it is forwarded into ``MultiModalConfig``, whose
+        validator normalizes each value into a ``*DummyOptions`` object. Hence
+        ``get_limit_per_prompt`` (which reads ``.count``) rather than comparing
+        the mapping's values to 0 directly.
+        """
+        mm_config = getattr(model_config, "multimodal_config", None)
+        if mm_config is None:
+            return True
+        limits = getattr(mm_config, "limit_per_prompt", None) or {}
+        return bool(limits) and all(
+            mm_config.get_limit_per_prompt(modality) == 0 for modality in limits
+        )
+
+    @classmethod
     def _resolve_vision_auto_config(
         cls, vllm_config: "VllmConfig", model_config
     ) -> None:
@@ -354,7 +385,18 @@ class NeuronPlatform(Platform):
         # max_num_batched_tokens. The encoder budget cap in NeuronScheduler
         # already prevents overflow without needing this flag.
 
-        if hasattr(model_config.hf_config, "vision_config"):
+        # ``hasattr`` is a weaker signal than it looks: some checkpoints' custom
+        # configuration_*.py set ``self.vision_config`` unconditionally (MiMo-V2.5
+        # does), so it is True even when the key is absent from config.json and no
+        # vision tower will ever run. Resolving vision config anyway forces a
+        # ``vision_attention_block_size`` (2048 by default) floor on the largest
+        # bucket, which makes a text-only server with max_model_len < 2048 abort:
+        # "Largest bucket (1024) is smaller than vision_attention_block_size".
+        # If the caller declared every modality limit as 0, no request can carry
+        # multimodal input, so skip vision sizing entirely.
+        if hasattr(model_config.hf_config, "vision_config") and not cls._mm_disabled(
+            model_config
+        ):
             cls._resolve_vision_auto_config(vllm_config, model_config)
 
         # Compute per-image embed limit for request validation.


### PR DESCRIPTION
## Summary

Ports MiMo-V2.5 to the PyTorch-native model layout under `vllm_neuron/model/mimo_v2_5/`: 48 layers, hidden 4096, 256 routed experts top-8, hybrid attention with 9 full-attention layers (0, 5, 11, 17, 23, 29, 35, 41, 47) and 39 sliding-window layers (window 128), asymmetric head dims (Q/K 192, V 128) and asymmetric KV heads (full 4, SWA 8).

Text decoder only — the released checkpoint is multimodal, but the vision/audio towers are not built here.

Also adds `NF.write_paged_kv_cache`, a shared in-place paged-KV scatter kernel for models whose head dim exceeds the fused attention kernels' 128 cap. It cuts MiMo-V2.5's decode from 199 to 128.5 ms/token; see the fourth reviewer note for why `index_put_` was so expensive.

## Notes for reviewers

Four things that are hard to see from the diff alone:

**Weights load straight from the HF checkpoint.** It stores matmul weights as 128x128 blockwise FP8-e4m3 with `*.weight_scale_inv` companions, which the loaders dequantize host-side, so no separate BF16 conversion pass is needed. The loaders pick their branch by probing the checkpoint for `*_scale_inv` keys (`_detect_quantized`), not by reading `quantization_config`.

**Attention runs eager with fp32 scores**, not through a fused kernel: the 192-wide Q/K heads exceed the 128 `head_dim` cap in `flash_attention`, `attention_decode`, and `segmented_attention`. The MoE does use the NKI kernels (`moe_cte` prefill, `moe_tkg` decode). This is the main thing I would like a second opinion on — if there is a fused path that tolerates 192-wide heads that I missed, it should replace this.

**`_prefill_block_size` derives the MoE dispatch block size from the token count** instead of using a fixed 256. The `shard_on_block` kernel faults on device (`indirect memory copy via vector DGE out-of-bound access`) once the block count grows past ~11, which a fixed block size crosses as soon as `max_model_len` reaches 1024. Measured at TP=64/EP=64 (E_local=4, top_k=8):

| T | block_size | N | result |
|---|---:|---:|---|
| 512 | 256 | 11 | ok |
| 1024 | 512 | 11 | ok |
| 1024 | 256 | 19 | FAULT |
| 1024 | 128 | 35 | FAULT |

Forcing the torch *mapping* path still faults; forcing the torch *MoE compute* makes the fault vanish — which localizes it to the dispatch kernel rather than the mapping or attention. N=35 has a per-shard count (18) divisible by the kernel's `BLOCK_PARALLEL_FACTOR` of 3 and still faults, so the trigger is the block count itself, not a divisibility condition. **This looks like a kernel bug worth filing separately** — the workaround here costs intra-block padding, and a fix in `bwmm_shard_on_block` would let the block size go back to being tuned for efficiency.

**The paged KV-cache write goes through a NKI kernel** (`NF.write_paged_kv_cache`, new) rather than `index_put_`. This was the decode bottleneck, and the reason is not local to this model, so it may be worth knowing about for other eager-attention ports:

`Tensor.index_put_` on a cache parameter is not an in-place write under neuronx-cc. XLA has no in-place scatter, so it lowers to a full-tensor `scatter` that materializes a copy of the *entire* cache pool, plus an identity `transpose dims=[0,1,2,3]` that is not elided. `AliasingOutputRewritePass` normally hides this by rewriting the last write per parameter into a true in-place update — which is why a microbenchmark shows nothing: with one write per buffer, `index_put_` measures *faster* than the kernel (0.076 vs 0.095 ms). It only bites at model scale, because `initialize_kv_cache` hands the same raw cache tensor to several layers (`for layer_name in tensor.shared_by`), so 48 layers' 96 writes land on 18 placeholders and chain. `_add_inplace_aliasing` emits one alias per mutated *placeholder*, not per write, so 78 intermediate full-pool copies survived — ~124 GB of pool traffic per decode step.

The kernel does an indirect (`vector_offset`) scatter-DMA straight into the cache and **returns** the cache tensors, which puts it on the pass's NKI path — that one chains `k0 -> k1 -> ... -> kN` across every write to a shared buffer instead of aliasing only the last. Two non-obvious constraints, both found by reading `aliasing_pass.py`: the kernel must return the inputs it writes (a NKI kernel that writes an input and returns nothing reports no `operand_output_aliases` *and* no outputs, so the write is dropped from the graph entirely), and the 4D->2D cache flatten must happen *inside* the kernel, because `_serialize_nki_write_aliases` only rewires writes whose FX shape matches the placeholder exactly.

Result: HLO `scatter` bytes 30.94 GB -> 12.3 MB, `transpose` 31.17 GB -> 246.5 MB, TPOT 199 -> 128.5 ms. It lives in `vllm_neuron/functional/attention/` rather than in the model directory because nothing about it is MiMo-specific — any model whose head dim exceeds the fused kernels' 128 cap needs it.

## Changes outside the model directory

- `vllm_neuron/model/registry.py` — one entry.
- `vllm_neuron/vllm/platform.py` — skip vision bucket sizing when no request can carry multimodal input. `hasattr(hf_config, "vision_config")` is a weaker signal than it looks, because MiMo's custom `configuration_mimo_v2.py` sets `self.vision_config` unconditionally; sizing vision anyway imposes a `vision_attention_block_size` (2048) floor on the largest bucket, which aborts a text-only server at `max_model_len=1024`.
- `vllm_neuron/functional/attention/kv_cache_write.py` — new, the scatter kernel described above.
- `vllm_neuron/functional/moe/moe_{blockwise,cte}.py` — two `VLLM_NEURON_MOE_*_FORCE_TORCH` env vars, +15 lines total, plus `VLLM_NEURON_KV_WRITE_FORCE_TORCH` in the new file. These are **diagnostic escape hatches, not a feature**: each forces a functionally equivalent torch fallback, which is how the DGE fault was narrowed to the dispatch kernel and how the KV write was A/B'd at long context. They default off. Happy to drop them if you would rather not carry debug switches in shared code.

## Performance

trn2.48xlarge, 900 in / 90 out, TP=64/EP=64, BF16, `vllm bench serve`. `max_num_seqs` is 32 except for the first row:

| max_num_seqs | concurrency | out tok/s | TTFT median (ms) | TPOT median (ms) | ITL median (ms) |
|---|---|---|---|---|---|
| 1 | 1 | 7.67 | 308 | 128.5 | 128.5 |
| 32 | 1 | 6.72 | 304 | 147.0 | 146.9 |
| 32 | 16 | 78.72 | 878 | 192.1 | 146.9 |
| 32 | 32 | 126.19 | 1522 | 232.4 | 146.8 |

Against the NxDI FP8 path on the same instance, prefill is ahead (TTFT 308 vs 485 ms at c=1) and decode is behind (TPOT 128.5 vs 58 ms, a ~2.2x gap where it used to be ~3.4x). The comparison is BF16 here vs FP8 there, so roughly 2x of the decode weight traffic is expected from precision alone.

For an off-instance reference point, 8xH100 on the same 900/90 workload at c=1 (SGLang `--tp 8` with context-parallel 2, and vLLM with chunked prefill) reaches TTFT 95 / 83 ms and TPOT 6.9 / 5.4 ms. So this port is ~3.2-3.7x behind H100 on prefill and ~19-24x behind on decode — **both are slower, and decode is the outlier, not prefill**. Worth stating plainly so the NxDI comparison above is not read as "prefill is fine".

Median ITL is flat at ~147 ms from concurrency 1 to 32, so decode pays a batch-invariant per-step cost, consistent with `moe_tkg(is_all_expert=True)` doing every local expert's matmuls regardless of how many tokens are in flight. Throughput accordingly keeps scaling with batch size.

That all-expert choice looked like the obvious thing to revisit: at EP=64 a rank owns `E_local = 4` of 256 experts and `top_k` is 8, so the *expected* number of selected experts on a rank is `8 x 4/256 = 0.125` — a rank has no selected expert at all ~88% of the time, yet computes all 4. **I chased that 32x and it is not available.** Both alternatives were measured on device and both lose, so the static path in this PR is deliberate:

- **`is_all_expert=False` (routed/selective) is EP-incompatible by construction.** `selective_expert_impl.py` indexes the *local* `[E_local, H, 2, I]` weight tensor with the *global* expert id from `expert_index` and takes no `rank_id` argument at all — global ids 0..255 into a size-4 array. That is presumably why `gpt_oss/model_bf16.py` force-enables all-expert whenever `ep_degree > 1`. It is also *more* work here, not less: it loops `for token: for k in range(top_k)` = 8 experts per token against all-expert's 4. And it does not compile at these dims (`Not enough memory for Down projection weights`).
- **`is_all_expert_dynamic=True` is slower end-to-end**, even though it is bit-exact. It skips token blocks with no routed tokens, and an isolated single-kernel microbenchmark made it look like a 1.2-1.55x win at T>=16. Served, with the same host and a fresh recompile each way, median ITL goes the other direction:

  | concurrency | static | dynamic (block=8) |
  |---|---|---|
  | 1  | 147.2 | 160.6 (+9.1%) |
  | 16 | 147.2 | 152.9 (+3.8%) |
  | 32 | 147.1 | 148.1 (+0.6%) |

  The microbenchmark timed one kernel per host round trip, so a ~0.2 ms/layer difference sat on ~1 ms of mostly-fixed dispatch overhead. In the real graph the kernel runs 47 times back-to-back, and the data-dependent control flow (`nl.dynamic_range` + `_find_routed_tokens`) costs more than the skipping saves — the +0.29 ms/layer penalty is the same magnitude as the claimed saving with the sign flipped. Recording this so the next person does not re-run the microbenchmark and reach my first (wrong) conclusion.

Two structural facts also cap this lever regardless of dispatch mode. `NUM_DYNAMIC_ALGO_STATIC_BLOCKS = 1` means one block per expert always executes, so dynamic dispatch can skip unrouted *token blocks* but never a whole unused expert — dropping that last block needs `all_to_all_v_strategy != DISABLED`, which the kernel restricts to Trn3 with MX weights. And `derive_from_dims` needs `T // block_size >= 2` with block_size divisible by 8, i.e. `T >= 16`, so BS=1 decode cannot reach the dynamic path at all and the 128.5 ms single-stream number is untouched by any of this.

A device profile of a single decode step (rank-gated `/start_profile`, all 64 cores, BS=1) says the bottleneck is **instruction issue, not bandwidth**:

| measured per decode step, per NeuronCore | value |
|---|---|
| `hbm_read_bytes` | 3.16 GB |
| achieved read bandwidth over 128.5 ms | 24.6 GB/s = **3.4% of the 725 GB/s per-core share** |
| tensor-engine instructions (2 logical cores) | 132,997 + 132,201 = **265,198** |
| per layer | **~5,525**, i.e. a ~0.485 us budget each |

Batch-1 MoE matvecs tile badly on the 128x128 PE array. Predicting the tile count from the MoE dims alone (hidden 4096, moe_intermediate 2048, 4 local experts at EP=64, gate+up+down, `ceil(K/128)*ceil(N/128)`) gives **6,144 per layer** against 5,525 measured — so the MoE matvecs are ~90% of every tensor instruction in the step, each moving a single-row operand through a 128-wide array. That also explains why median ITL is flat from concurrency 1 to 32: more tokens ride the same instruction stream.

This also rules out the intuition that a 30B-class model should just use fewer cores. Predicted MoE tiles per layer is `E_local * (ceil(H/128)*ceil(2*I/128) + ceil(I/128)*ceil(H/128))`, and it is **invariant at 6,144 across EP=64/32/16/8/4** — halving the split doubles `E_local` and halves `I_local`, which cancel exactly. Fewer cores therefore buys no instruction reduction on the dominant term while giving up HBM headroom. Consistent with the collective measurement: at BS=1 the decode all-reduce moves 0.79 MB/step against 3.16 GB of HBM read, so inter-core traffic is 0.025% of the step and is not what to attack.

Two corrections to my own earlier framing, since both were wrong: a bandwidth roofline is the wrong model here (I had assumed all 9.66 GB of local expert weights are read every step; only 3.16 GB actually is, 0.223x the 14.17 GB shard), and `_gather_paged_kv` / the fp32 attention scores are not the suspects — the residual is context-independent, adding only ~6 ms for 5,900 extra context tokens. The lever is arithmetic density per instruction, not weight traffic.

## Testing

The repo has no test suite, so validation was on-device and manual:

- BS=1 at SEQ=512 and SEQ=1024, coherent output under `--chat`.
- BS=32 at SEQ=1024 via `vllm serve`, smoke-tested through `/v1/completions`, then the benchmark sweep above.
- The block-size fix cross-checked against the torch-MoE reference: output matched word-for-word on 3 of 4 prompts.
- The KV scatter kernel checked against the `index_put_` reference it replaces, on placement, non-clobbering of untouched slots, `slot_mapping < 0` skips, the `nkh=2` head-stride term, and `d=128` (5/5 pass).
- Long-context retrieval at SEQ=8192, greedy: a needle planted mid-prompt is recovered at every input length from 64 to 6865 tokens, and at every depth from 0% to 99% of a 6800-token prompt; four needles at four depths come back correct and in order. This is the sharp test for the scatter, because `sliding_window` is 128 — a needle thousands of tokens back rides only the 9 full-attention layers, so it exercises cache rows spread across the whole pool rather than a recent window. A 400-token generation from a 6800-token prompt stays coherent through the tail.
- A/B against the old `index_put_` path at SEQ=8192 (`VLLM_NEURON_KV_WRITE_FORCE_TORCH=1`), greedy, same 7 prompts: **6/7 completions byte-identical**. The exception is the 400-token free-form generation, which splits 25 tokens in (after `"a wooden "`, one path continuing `"sign that has been repainted..."` and the other `"door that sticks a little..."`); both stay fluent and both tails are clean. The server is self-deterministic (same prompt twice, byte-identical), so that split is caused by the graph change rather than run-to-run noise — but the unit test shows the kernel writes byte-identical cache contents to `index_put_`, so what differs is op ordering downstream of the rewired reads, not the cached values. Every short and retrieval-style answer, where a wrong cache row would actually change the answer, matches exactly. I could not measure the logit margin at the split to confirm it is a tie-break, because on-device sampling strips logprobs.

**Not validated:** BS > 32 (each `(max_num_seqs, max_model_len)` needs its own compile). One known rough edge: output quality degrades on a `"1 2 3 4 5 6 7 8 9"` continuation prompt. Compiler version (cc 2.26 vs 2.25) and the NKI top-k path are both ruled out; root cause still open. It predates the KV scatter and is unchanged by it. Ordinary prose and chat prompts look fine.

Chunked prefill / prefix caching are not implemented (`kv_segment_size` must be 0) and raise explicitly rather than silently mis-computing.

